### PR TITLE
Add copyright, license, and license-file to cabal file

### DIFF
--- a/flexdis86.cabal
+++ b/flexdis86.cabal
@@ -2,6 +2,9 @@ Name:          flexdis86
 Version:       0.1.3
 Author:        Galois Inc.
 Maintainer:    jhendrix@galois.com, tristan@galois.com
+Copyright:     (c) Galois, Inc 2018
+License:       BSD3
+License-file:  LICENSE
 Build-type:    Simple
 Cabal-version: >= 1.10
 Synopsis: A disassembler and assembler for x86


### PR DESCRIPTION
These are read by [cabal2nix](https://github.com/NixOS/cabal2nix), which makes this package "unfree" in the eyes of Nix.