### PR TITLE
Test disassembly of .text sections of sample binaries

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "deps/elf-edit"]
 	path = deps/elf-edit
 	url = git@github.com:GaloisInc/elf-edit.git
+[submodule "deps/sample-binaries"]
+	path = deps/sample-binaries
+	url = https://github.com/GaloisInc/sample-binaries

--- a/flexdis86.cabal
+++ b/flexdis86.cabal
@@ -77,6 +77,7 @@ test-suite flexdis86-tests
                  base,
                  bytestring,
                  directory >=1.3 && < 2,
+                 filepath,
                  tasty >= 0.10,
                  tasty-hunit,
                  process >= 1.2 && < 1.7,

--- a/flexdis86.cabal
+++ b/flexdis86.cabal
@@ -76,6 +76,7 @@ test-suite flexdis86-tests
   build-depends: flexdis86,
                  base,
                  bytestring,
+                 directory >=1.3 && < 2,
                  tasty >= 0.10,
                  tasty-hunit,
                  process >= 1.2 && < 1.7,
@@ -86,6 +87,7 @@ test-suite flexdis86-tests
                  pretty-show
   other-modules:
     Assemble
+    Binaries
     Roundtrip
     Util
 

--- a/tests/Binaries.hs
+++ b/tests/Binaries.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Binaries ( binaryTests ) where
+
+import           Data.ElfEdit as ElfEdit
+import           Data.Foldable ( for_ )
+import qualified Data.ByteString as LB
+import           Data.Maybe ( catMaybes, fromMaybe )
+import qualified Test.Tasty as T
+import qualified Test.Tasty.HUnit as T
+import qualified System.Directory as Directory
+import           System.Environment ( lookupEnv )
+import           System.IO.Temp ( withSystemTempFile )
+import qualified System.IO as IO
+
+import qualified Flexdis86 as D
+
+getTextSection :: FilePath -> IO LB.ByteString
+getTextSection binPath = do
+  elfBS <- LB.readFile binPath
+  let elf64 =
+        case ElfEdit.parseElf elfBS of
+          ElfEdit.Elf64Res _ elf -> elf
+          _ -> error "Couldn't parse ELF"
+  case ElfEdit.findSectionByName ".text" elf64 of
+    [sec] -> pure $ ElfEdit.elfSectionData sec
+    _ -> error "Couldn't find single .text section"
+
+binaryTests :: T.TestTree
+binaryTests = T.testCase "Disassemble/reassemble binaries" $ do
+  let hasExt ext = (== ext) . reverse . take (length ext) . reverse
+  binDir <- fromMaybe "deps/sample-binaries/tiny/" <$>
+    lookupEnv "FLEXDIS_SAMPLE_BINARIES"
+  bins <- filter (hasExt ".x86_64-exe") <$> Directory.listDirectory binDir
+  T.assertBool
+    ("Enough tests (" ++ show (length bins) ++ ")")
+    (length bins > 0)
+  for_ bins $ \binPath -> do
+    let minLength = 0
+    codeBytes <- getTextSection (binDir ++ binPath)
+    let disBuf = D.disassembleBuffer codeBytes
+    T.assertBool
+      ("Disassembled something in " ++ binPath)
+      (length disBuf > minLength)
+    let disIns = map D.disInstruction disBuf
+    T.assertBool
+      ("Disassembled some instructions in " ++ binPath)
+      (length (catMaybes disIns) > minLength)
+
+
+    -- Force full evaluation by writing to a file
+    withSystemTempFile "flexdis86-disassemble-test.txt" $ \_fp handle -> do
+      -- For debugging:
+      -- putStrLn $ "In file " ++ binPath
+      for_ disBuf $ \instr -> do
+        -- putStrLn $ "At offset " ++ (show (D.disOffset instr))
+        IO.hPutStrLn handle (show (D.disOffset instr))
+
+    -- TODO(lb): It would be nice if we could roundtrip all these binaries, but
+    -- at the moment some fail. This would also obviate the hack of writing to
+    -- file above.
+
+    -- case sequence disIns of
+    --   Nothing -> fail $ "Not everything got disassembled: " ++ binPath
+    --   Just disIns' -> do
+    --     asIns <- traverse D.assembleInstruction disIns'
+    --     let assembledInsns = B.toLazyByteString . mconcat $ asIns
+    --     T.assertEqual "Roundtrip" codeBytes (LB.toStrict assembledInsns)

--- a/tests/Binaries.hs
+++ b/tests/Binaries.hs
@@ -2,16 +2,17 @@
 
 module Binaries ( binaryTests ) where
 
+import qualified Data.ByteString as LB
 import           Data.ElfEdit as ElfEdit
 import           Data.Foldable ( for_ )
-import qualified Data.ByteString as LB
 import           Data.Maybe ( catMaybes, fromMaybe )
-import qualified Test.Tasty as T
-import qualified Test.Tasty.HUnit as T
 import qualified System.Directory as Directory
 import           System.Environment ( lookupEnv )
-import           System.IO.Temp ( withSystemTempFile )
+import           System.FilePath ( (</>) )
 import qualified System.IO as IO
+import           System.IO.Temp ( withSystemTempFile )
+import qualified Test.Tasty as T
+import qualified Test.Tasty.HUnit as T
 
 import qualified Flexdis86 as D
 
@@ -37,7 +38,7 @@ binaryTests = T.testCase "Disassemble/reassemble binaries" $ do
     (length bins > 0)
   for_ bins $ \binPath -> do
     let minLength = 0
-    codeBytes <- getTextSection (binDir ++ binPath)
+    codeBytes <- getTextSection (binDir </> binPath)
     let disBuf = D.disassembleBuffer codeBytes
     T.assertBool
       ("Disassembled something in " ++ binPath)

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -6,11 +6,13 @@ import qualified Test.Tasty as T
 
 #if defined(ARCH_ELF)
 import Assemble ( assembleTests )
+import Binaries ( binaryTests )
 import Roundtrip ( roundtripTests )
 
 elfCases :: [T.TestTree]
 elfCases =
   [ assembleTests
+  , binaryTests
   , roundtripTests
   ]
 #else


### PR DESCRIPTION
Some tests for disassembly of some small binaries. Having a test suite like this is nice because

 1. It will benefit from any work done upstream on `sample-binaries`, which can benefit multiple projects across Galois
 2. It is really easy to compile a hairy binary, toss it into `tests/data`, increment the expected number of tests, and test that Flexdis86 can disassemble it.