### PR TITLE
Update/ghc 8.8

### DIFF
--- a/flexdis86.cabal
+++ b/flexdis86.cabal
@@ -20,7 +20,7 @@ library
     containers,
     directory,
     filepath,
-    lens,
+    lens >= 3.8,
     mtl,
     template-haskell,
     vector,

--- a/src/Flexdis86/ByteReader.hs
+++ b/src/Flexdis86/ByteReader.hs
@@ -71,7 +71,7 @@ class (Applicative m, Monad m) => ByteReader m where
 
   -- | Invalid instruction when parsing
   invalidInstruction :: m a
-  invalidInstruction = fail "Invalid instruction"
+  invalidInstruction = error "Invalid instruction"
 
   readSByte :: m Int8
   readSByte  = fromIntegral <$> readByte

--- a/src/Flexdis86/Disassembler.hs
+++ b/src/Flexdis86/Disassembler.hs
@@ -682,7 +682,7 @@ parseValue p osz mmrm tp = do
                0 -> readNoOffset p modRM
                1 -> readWithOffset read_disp8  aso p modRM
                2 -> readWithOffset read_disp32 aso p modRM
-               _ -> fail $ "internal: parseValue given modRM to register with operand type: " ++ show tp
+               _ -> error $ "internal: parseValue given modRM to register with operand type: " ++ show tp
       rm_reg :: Word8
       rm_reg = rex_b rex .|. modRM_rm modRM
 
@@ -693,7 +693,7 @@ parseValue p osz mmrm tp = do
       | otherwise            -> memSizeFn osz sz <$> addr
     OpType ModRM_rm_mod3 sz
       | modRM_mod modRM == 3 -> pure $ regSizeFn osz rex sz rm_reg
-      | otherwise -> fail $ "Unexpected memory operand in parseValue"
+      | otherwise -> error "Unexpected memory operand in parseValue"
     OpType ModRM_reg sz -> pure $ regSizeFn osz rex sz reg_with_rex
     OpType (Opcode_reg r) sz -> pure $ regSizeFn osz rex sz (rex_b rex .|. r)
     OpType (Reg_fixed r) sz  -> pure $ regSizeFn osz rex sz r

--- a/src/Flexdis86/OpTable.hs
+++ b/src/Flexdis86/OpTable.hs
@@ -44,6 +44,7 @@ module Flexdis86.OpTable
   ) where
 
 import           Control.Applicative
+import qualified Control.Monad.Fail as MF
 import           Control.Lens
 import           Control.Monad.State
 import           Data.Bits ((.&.), (.|.), shiftR, shiftL)
@@ -98,6 +99,8 @@ instance Monad ElemParser where
   return = pure
   m >>= h = EP $ \s -> do (v,s') <- unEP m s
                           unEP (h v) s'
+
+instance MF.MonadFail ElemParser where
   fail e = EP $ \s -> Left $ show (esLine s) ++ ": " ++  e
 
 instance MonadState ElemState ElemParser where
@@ -551,7 +554,7 @@ setDefCPUReq r = do
   when (creq == Base) $ defCPUReq .= r
 
 -- | Parse opcode value
-parse_opcode :: MonadState Def m => String -> m ()
+parse_opcode :: (MonadState Def m, MF.MonadFail m) => String -> m ()
 parse_opcode nm = do
   case readHex nm of
     [(v,"")] -> addOpcode v

--- a/src/Flexdis86/OpTable.hs
+++ b/src/Flexdis86/OpTable.hs
@@ -467,76 +467,76 @@ data Def = Def  { _defMnemonic :: String
                 } deriving (Eq, Show)
 
 -- | Canonical mnemonic for definition.
-defMnemonic :: Simple Lens Def String
+defMnemonic :: Lens' Def String
 defMnemonic = lens _defMnemonic (\s v -> s { _defMnemonic = v })
 
 -- | Additional mnemonics, not including the canonical mnemonic.
 --
 -- Used e.g. by jump instructions.
-defMnemonicSynonyms :: Simple Lens Def [String]
+defMnemonicSynonyms :: Lens' Def [String]
 defMnemonicSynonyms =
   lens _defMnemonicSynonyms (\s v -> s { _defMnemonicSynonyms = v })
 
 -- | CPU requirements on the definition.
-defCPUReq :: Simple Lens Def CPURequirement
+defCPUReq :: Lens' Def CPURequirement
 defCPUReq = lens _defCPUReq (\s v -> s { _defCPUReq = v })
 
 -- | Vendor requirements on the definition.
-defVendor :: Simple Lens Def (Maybe Vendor)
+defVendor :: Lens' Def (Maybe Vendor)
 defVendor = lens _defVendor (\s v -> s { _defVendor = v })
 
 -- | Restrictions on the mode of the CPU.
-modeLimit :: Simple Lens Def ModeLimit
+modeLimit :: Lens' Def ModeLimit
 modeLimit = lens _modeLimit (\s v -> s { _modeLimit = v })
 
 -- | Modifications to x64 mode.
-defMode :: Simple Lens Def (Maybe Mode)
+defMode :: Lens' Def (Maybe Mode)
 defMode = lens _defMode (\s v -> s { _defMode = v })
 
 -- | Expected address size for instruction.
-reqAddrSize :: Simple Lens Def (Maybe SizeConstraint)
+reqAddrSize :: Lens' Def (Maybe SizeConstraint)
 reqAddrSize = lens _reqAddrSize (\s v -> s { _reqAddrSize = v })
 
 -- | Expected operand size for instruction.
-reqOpSize :: Simple Lens Def (Maybe OperandSizeConstraint)
+reqOpSize :: Lens' Def (Maybe OperandSizeConstraint)
 reqOpSize = lens _reqOpSize (\s v -> s { _reqOpSize = v })
 
 -- | Prefixes allowed on instruction.
-defPrefix :: Simple Lens Def [String]
+defPrefix :: Lens' Def [String]
 defPrefix = lens _defPrefix (\s v -> s { _defPrefix = v })
 
 -- | Prefixe required by an instruction, if any.
-requiredPrefix :: Simple Lens Def (Maybe Word8)
+requiredPrefix :: Lens' Def (Maybe Word8)
 requiredPrefix = lens _requiredPrefix (\s v -> s { _requiredPrefix = v })
 
 -- | Opcodes on instruction.
-defOpcodes :: Simple Lens Def [Word8]
+defOpcodes :: Lens' Def [Word8]
 defOpcodes = lens _defOpcodes (\s v -> s { _defOpcodes = v })
 
 -- | Constraint on the modRM.mod value.
-requiredMod :: Simple Lens Def (Maybe ModConstraint)
+requiredMod :: Lens' Def (Maybe ModConstraint)
 requiredMod = lens _requiredMod (\s v -> s { _requiredMod = v })
 
 -- | Indicates if instruction must have ModR/M value with the
 -- given value in the reg field.
-requiredReg :: Simple Lens Def (Maybe Fin8)
+requiredReg :: Lens' Def (Maybe Fin8)
 requiredReg = lens _requiredReg (\s v -> s { _requiredReg = v })
 
 -- | Indicates if instruction must have ModR/M value with the
 -- given value in the rm field.
-requiredRM :: Simple Lens Def (Maybe Fin8)
+requiredRM :: Lens' Def (Maybe Fin8)
 requiredRM = lens _requiredRM (\s v -> s { _requiredRM = v })
 
 -- | An x87 FPU opcode expected in the low 6-bits of a ModRM byte
 -- following instruction.
-x87ModRM :: Simple Lens Def (Maybe Fin64)
+x87ModRM :: Lens' Def (Maybe Fin64)
 x87ModRM = lens _x87ModRM (\s v -> s { _x87ModRM = v })
 
-vexPrefixes :: Simple Lens Def [[Word8]]
+vexPrefixes :: Lens' Def [[Word8]]
 vexPrefixes = lens _vexPrefixes (\s v -> s { _vexPrefixes = v })
 
 -- | Operand descriptions.
-defOperands :: Simple Lens Def [OperandType]
+defOperands :: Lens' Def [OperandType]
 defOperands = lens _defOperands (\s v -> s { _defOperands = v })
 
 -- | Return true if this definition is one supported by flexdis86.

--- a/src/Flexdis86/OpTable.hs
+++ b/src/Flexdis86/OpTable.hs
@@ -6,7 +6,7 @@ Maintainer  :  jhendrix@galois.com
 This declares the parser for optable.xml file, which is used to define the
 instruction set.
 -}
-
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -99,6 +99,9 @@ instance Monad ElemParser where
   return = pure
   m >>= h = EP $ \s -> do (v,s') <- unEP m s
                           unEP (h v) s'
+#if !(MIN_VERSION_base(4,13,0))
+  fail = MF.fail
+#endif
 
 instance MF.MonadFail ElemParser where
   fail e = EP $ \s -> Left $ show (esLine s) ++ ": " ++  e

--- a/src/Flexdis86/Prefixes.hs
+++ b/src/Flexdis86/Prefixes.hs
@@ -61,7 +61,7 @@ vexLens :: (Word8 -> a) ->
            (Word8 -> Word8 -> a) ->
            (Word8 -> a -> Word8) ->
            (Word8 -> Word8 -> a -> (Word8,Word8)) ->
-           Simple Lens VEX a
+           Lens' VEX a
 vexLens get1 get2 upd1 upd2 = lens getter updater
   where getter vex = case vex of
                        VEX2 b     -> get1 b
@@ -72,7 +72,7 @@ vexLens get1 get2 upd1 upd2 = lens getter updater
                                         in VEX3 b1' b2'
 
 -- | Are we using 256-bit vectors
-vex256 :: Simple Lens VEX Bool
+vex256 :: Lens' VEX Bool
 vex256 = vexLens gt (\_ b2 -> gt b2)
                  st (\b1 b2 a -> (b1, st b2 a))
   where
@@ -81,7 +81,7 @@ vex256 = vexLens gt (\_ b2 -> gt b2)
 
 
 -- | REX info from VEX prefix
-vexRex :: Simple Lens VEX REX
+vexRex :: Lens' VEX REX
 vexRex = vexLens gt1 gt2 st1 st2
   where
   gt1 b      = REX (0x40 B..|. B.shiftR (B.complement b B..&. 0x80) 5)
@@ -95,7 +95,7 @@ vexRex = vexLens gt1 gt2 st1 st2
 
 -- | The VVVV field.  We return it as is.  Note that when used to encode
 -- registers, the byte needs to be complemented.
-vexVVVV :: Simple Lens VEX Word8
+vexVVVV :: Lens' VEX Word8
 vexVVVV = vexLens gt (\_ b2 -> gt b2)
                   st (\b1 b2 v -> (b1, st b2 v))
   where
@@ -114,19 +114,19 @@ setBitTo bits bitNo val
   | otherwise = B.clearBit bits bitNo
 
 -- | Indicates if 64-bit operand size should be used.
-rexW :: Simple Lens REX Bool
+rexW :: Lens' REX Bool
 rexW = lens ((`B.testBit` 3) . unREX) (\(REX r) v -> REX (setBitTo r 3 v))
 
 -- | Extension of ModR/M reg field.
-rexR :: Simple Lens REX Bool
+rexR :: Lens' REX Bool
 rexR = lens ((`B.testBit` 2) . unREX) (\(REX r) v -> REX (setBitTo r 2 v))
 
 -- | Extension of SIB index field.
-rexX :: Simple Lens REX Bool
+rexX :: Lens' REX Bool
 rexX = lens ((`B.testBit` 1) . unREX) (\(REX r) v -> REX (setBitTo r 1 v))
 
 -- | Extension of ModR/M r/m field, SIB base field, or Opcode reg field.
-rexB :: Simple Lens REX Bool
+rexB :: Lens' REX Bool
 rexB = lens ((`B.testBit` 0) . unREX) (\(REX r) v -> REX (setBitTo r 0 v))
 
 instance Show REX where
@@ -136,22 +136,22 @@ instance Show REX where
 newtype SegmentPrefix = SegmentPrefix { unwrapSegmentPrefix :: Word8 }
   deriving (Eq, Show)
 
-prLockPrefix :: Simple Lens Prefixes LockPrefix
+prLockPrefix :: Lens' Prefixes LockPrefix
 prLockPrefix = lens _prLockPrefix (\s v -> s { _prLockPrefix = v })
 
-prSP :: Simple Lens Prefixes SegmentPrefix
+prSP :: Lens' Prefixes SegmentPrefix
 prSP = lens _prSP (\s v -> s { _prSP = v})
 
-prREX :: Simple Lens Prefixes REX
+prREX :: Lens' Prefixes REX
 prREX = lens _prREX (\s v -> s { _prREX = v })
 
-prVEX :: Simple Lens Prefixes (Maybe VEX)
+prVEX :: Lens' Prefixes (Maybe VEX)
 prVEX = lens _prVEX (\s v -> s { _prVEX = v })
 
-prASO :: Simple Lens Prefixes Bool
+prASO :: Lens' Prefixes Bool
 prASO = lens _prASO (\s v -> s { _prASO = v })
 
-prOSO :: Simple Lens Prefixes Bool
+prOSO :: Lens' Prefixes Bool
 prOSO = lens _prOSO (\s v -> s { _prOSO = v })
 
 prAddrSize :: Prefixes -> SizeConstraint

--- a/src/Flexdis86/Segment.hs
+++ b/src/Flexdis86/Segment.hs
@@ -64,7 +64,7 @@ instance Show Segment where
 segmentRegisterByIndex :: Monad m => Word8 -> m Segment
 segmentRegisterByIndex r
   | r < 6 = return (Segment r)
-  | otherwise = fail "Invalid segment register."
+  | otherwise = error "Invalid segment register."
 
 segmentRegNo :: Segment -> Word8
 segmentRegNo (Segment r) = r

--- a/utils/DumpInstr.hs
+++ b/utils/DumpInstr.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Main where
@@ -26,6 +27,10 @@ instance ByteReader SimpleByteReader where
 instance Monad SimpleByteReader where
   return v      = SBR (return v)
   (SBR v) >>= f = SBR $ v >>= unSBR . f
+#if !(MIN_VERSION_base(4,13,0))
+  fail = Fail.fail
+#endif
+
 
 instance Fail.MonadFail SimpleByteReader where
   fail s        = SBR $ throwError s

--- a/utils/DumpInstr.hs
+++ b/utils/DumpInstr.hs
@@ -4,6 +4,7 @@ module Main where
 
 import           Control.Monad (when)
 import           Control.Monad.Except
+import qualified Control.Monad.Fail as Fail
 import           Control.Monad.State
 import qualified Data.ByteString as BS
 import           Numeric (readHex)
@@ -25,6 +26,8 @@ instance ByteReader SimpleByteReader where
 instance Monad SimpleByteReader where
   return v      = SBR (return v)
   (SBR v) >>= f = SBR $ v >>= unSBR . f
+
+instance Fail.MonadFail SimpleByteReader where
   fail s        = SBR $ throwError s
 
 


### PR DESCRIPTION
This updates us to 8.8 and uses MonadFail explicitly.  This will break compatibility with pre-8.0 GHC.