### PR TITLE
Fix a bug introduced while adding ghc-8.8 compatibility

### DIFF
--- a/src/Flexdis86/ByteReader.hs
+++ b/src/Flexdis86/ByteReader.hs
@@ -12,6 +12,7 @@ module Flexdis86.ByteReader
   ) where
 
 import Control.Applicative
+import qualified Control.Monad.Fail as MF
 import Data.Binary.Get (Get, getWord8)
 import Data.Bits
 import Data.Int
@@ -49,7 +50,7 @@ readLSB :: (Monad m, Bits b, Num b)
 readLSB = readLSB' 0 0
 
 -- | A reader monad for reading values from a stream.
-class (Applicative m, Monad m) => ByteReader m where
+class (Applicative m, Monad m, MF.MonadFail m) => ByteReader m where
   -- | Read a byte.
   readByte :: HasCallStack => m Word8
 
@@ -71,7 +72,7 @@ class (Applicative m, Monad m) => ByteReader m where
 
   -- | Invalid instruction when parsing
   invalidInstruction :: m a
-  invalidInstruction = error "Invalid instruction"
+  invalidInstruction = fail "Invalid instruction"
 
   readSByte :: m Int8
   readSByte  = fromIntegral <$> readByte


### PR DESCRIPTION
This fixes #15.  The first attempt at ghc-8.8 changed uses of `fail` in the
`ByteReader` to use error instead, as it wasn't immediately obvious that all of
the concrete classes implementing it could be instances of MonadFail.  It turns
out that they can be and that we are relying on that for correct behavior.  This
change reverts to using `fail` in a few places.

It would be really nice to make these failures a bit more structured.