### PR TITLE
DRY x2

### DIFF
--- a/src/Flexdis86/InstructionSet.hs
+++ b/src/Flexdis86/InstructionSet.hs
@@ -14,6 +14,8 @@ module Flexdis86.InstructionSet
   , ppInstructionWith
   , Value(..)
   , ppValue
+  , qwordFromInteger
+  , qwordFromIntegral
   , Displacement(..)
   , AddrRef(..)
   , module Flexdis86.Relocation
@@ -190,6 +192,14 @@ data Value
   | QWordReg Reg64
   | JumpOffset !JumpSize !JumpOffset
   deriving (Show, Eq, Ord)
+
+-- | Create a QWord immediate.
+qwordFromInteger :: Integer -> Value
+qwordFromInteger = QWordImm . UImm64Concrete . fromInteger
+
+-- | Create a QWord immediate.
+qwordFromIntegral :: Integral a => a -> Value
+qwordFromIntegral = QWordImm . UImm64Concrete . fromIntegral
 
 ppShowReg :: Show r => r -> Doc
 ppShowReg r = text (show r)

--- a/tests/Util.hs
+++ b/tests/Util.hs
@@ -8,7 +8,6 @@ module Util
 import           Control.Monad ( when )
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as B8
-import qualified System.Exit as IO
 import qualified System.IO as IO
 import qualified System.IO.Temp as IO
 import qualified System.Process as P
@@ -22,12 +21,7 @@ start_sym_name = "_start"
 readCodeSegment :: FilePath -> IO B.ByteString
 readCodeSegment fp = do
   bytes <- B.readFile fp
-  case E.parseElf bytes of
-    E.ElfHeaderError off msg -> error ("Failed to parse ELF header at offset " ++ show off ++ ": " ++ msg)
-    E.Elf32Res [] someElf -> extractCodeSegment someElf
-    E.Elf64Res [] someElf -> extractCodeSegment someElf
-    E.Elf32Res errs _ -> error ("Errors while parsing ELF file: " ++ show errs)
-    E.Elf64Res errs _ -> error ("Errors while parsing ELF file: " ++ show errs)
+  E.parseElfOrDie extractCodeSegment extractCodeSegment bytes
 
 extractCodeSegment :: E.Elf w -> IO B.ByteString
 extractCodeSegment e = do


### PR DESCRIPTION
Two small quality-of-life changes. The first is to use the API exposed by [this pull request](https://github.com/GaloisInc/elf-edit/pull/13) for centralizing the pattern of "die if parsing the elf failed". The second is to offer operations to downstream consumers for writing quadword literals a tiny bit more conveniently; this is done a pretty fair number of times in renovate.