### PR TITLE
Fix roundtrip of mov from memory

### DIFF
--- a/tests/Roundtrip.hs
+++ b/tests/Roundtrip.hs
@@ -247,6 +247,11 @@ twoOperandOpcodes = [ ("test reg reg (eax)", ["test %eax, %eax"])
                     , ("movzwl (%rcx,%rdx,2),%eax", ["movzwl (%rcx,%rdx,2),%eax"])
                     , ("mov    %al,(%r14,%rbx,1)", ["mov    %al,(%r14,%rbx,1)"])
                     , ("xor %r14d,%r14d", ["xor %r14d,%r14d"])
+                    , ("mov %rdi,0x601000", ["mov %rdi,0x601000"])
+                    , ("mov %rsi,0x601000", ["mov %rsi,0x601000"])
+                    , ("mov %rdi,0x501000", ["mov %rdi,0x501000"])
+                    , ("mov %edi,0x501000", ["mov %edi,0x501000"])
+                    , ("mov %rdi,0x401000", ["mov %rdi,0x401000"])
                     ]
 
 mmxTests :: T.TestTree


### PR DESCRIPTION
Fixes #20 

This definitely fixes that test, but I'm not 100% sure that it's the _right_ fix. I'm new to reading the ISA manual and don't have a firm grasp of the instruction encoding.

I looked at the ISA manual Table 2-2, "32-Bit Addressing Forms with the ModR/M byte" to figure out that the value in this case should be `0x4`.