### PR TITLE
Add support for decoding some missing AVX2 instructions

### DIFF
--- a/data/optable.xml
+++ b/data/optable.xml
@@ -5514,6 +5514,18 @@
       </def>
     </instruction>
 
+    <instruction>
+      <mnemonic>vpaddq</mnemonic>
+      <class>avx</class>
+      <def>
+        <opc>/vex=NDS.128.66.0F.WIG D4</opc>
+        <opr>Vx Hx Wx</opr>
+      </def>
+      <def>
+        <opc>/vex=NDS.256.66.0F.WIG D4</opc>
+        <opr>Vx Hx Wx</opr>
+      </def>
+    </instruction>
 
     <instruction>
         <mnemonic>paddsb</mnemonic>

--- a/data/optable.xml
+++ b/data/optable.xml
@@ -8921,6 +8921,32 @@
     </instruction>
 
     <instruction>
+        <mnemonic>vpsrld</mnemonic>
+        <class>avx</class>
+        <def>
+            <opc>/vex=NDD.128.66.0F.WIG 72 /reg=2</opc>
+            <opr>Hx Ux Ib</opr>
+        </def>
+        <def>
+            <opc>/vex=NDD.256.66.0F.WIG 72 /reg=2</opc>
+            <opr>Hx Ux Ib</opr>
+        </def>
+    </instruction>
+
+    <instruction>
+        <mnemonic>vpsrlq</mnemonic>
+        <class>avx</class>
+        <def>
+            <opc>/vex=NDD.128.66.0F.WIG 73 /reg=2</opc>
+            <opr>Hx Ux Ib</opr>
+        </def>
+        <def>
+            <opc>/vex=NDD.256.66.0F.WIG 73 /reg=2</opc>
+            <opr>Hx Ux Ib</opr>
+        </def>
+    </instruction>
+
+    <instruction>
         <mnemonic>punpckhqdq</mnemonic>
         <def>
             <pfx>aso rexr rexx rexb</pfx>


### PR DESCRIPTION
Specifically, this PR adds support for `vpsrld`, `vpsrlq`, and `vpaddq`.