### PR TITLE
Add decodings for some more AVX instructions

### DIFF
--- a/data/optable.xml
+++ b/data/optable.xml
@@ -5514,6 +5514,18 @@
       </def>
     </instruction>
 
+    <instruction>
+      <mnemonic>vpaddq</mnemonic>
+      <class>avx</class>
+      <def>
+        <opc>/vex=NDS.128.66.0F.WIG D4</opc>
+        <opr>Vx Hx Wx</opr>
+      </def>
+      <def>
+        <opc>/vex=NDS.256.66.0F.WIG D4</opc>
+        <opr>Vx Hx Wx</opr>
+      </def>
+    </instruction>
 
     <instruction>
         <mnemonic>paddsb</mnemonic>

--- a/data/optable.xml
+++ b/data/optable.xml
@@ -5502,6 +5502,19 @@
     </instruction>
 
     <instruction>
+      <mnemonic>vpaddb</mnemonic>
+      <class>avx</class>
+      <def>
+        <opc>/vex=NDS.128.66.0F.WIG FC</opc>
+        <opr>Vx Hx Wx</opr>
+      </def>
+      <def>
+        <opc>/vex=NDS.256.66.0F.WIG FC</opc>
+        <opr>Vx Hx Wx</opr>
+      </def>
+    </instruction>
+
+    <instruction>
       <mnemonic>vpaddd</mnemonic>
       <class>avx</class>
       <def>

--- a/data/optable.xml
+++ b/data/optable.xml
@@ -8495,6 +8495,15 @@
     </instruction>
 
     <instruction>
+      <mnemonic>vxorps</mnemonic>
+      <class>avx</class>
+      <def>
+        <opc>/vex=NDS.128.0F.WIG 57</opc>
+        <opr>Vx Hx Wx</opr>
+      </def>
+    </instruction>
+
+    <instruction>
         <mnemonic>xcryptecb</mnemonic>
         <def>
             <opc>0f a7 /mod=11 /rm=0 /reg=1</opc>
@@ -9110,14 +9119,22 @@
     </instruction>
 
     <instruction>
-     <mnemonic>vpunpcklqdq</mnemonic>
-     <class>avx</class>
-     <def>
-       <opc>/vex=NDS.128.66.0F.WIG 6C</opc>
-       <opr>Vx Hx Wx</opr>
-     </def>
+      <mnemonic>vpunpcklqdq</mnemonic>
+      <class>avx</class>
+      <def>
+        <opc>/vex=NDS.128.66.0F.WIG 6C</opc>
+        <opr>Vx Hx Wx</opr>
+      </def>
     </instruction>
 
+    <instruction>
+      <mnemonic>vpunpckhqdq</mnemonic>
+      <class>avx</class>
+      <def>
+        <opc>/vex=NDS.128.66.0F.WIG 6D</opc>
+        <opr>Vx Hx Wx</opr>
+      </def>
+    </instruction>
 
     <instruction>
         <mnemonic>phaddw</mnemonic>

--- a/src/Flexdis86/OpTable.hs
+++ b/src/Flexdis86/OpTable.hs
@@ -545,7 +545,7 @@ defOperands = lens _defOperands (\s v -> s { _defOperands = v })
 -- | Return true if this definition is one supported by flexdis86.
 defSupported :: Def -> Bool
 defSupported d = d^.reqAddrSize /= Just Size16
-                 && (d^.defCPUReq `elem` [Base, SSE, SSE2, SSE3, SSE4_1, SSE4_2, X87, AESNI, AVX, BMI2, ADX])
+                 && (d^.defCPUReq `elem` [Base, SSE, SSE2, SSE3, SSE3_atom, SSE4_1, SSE4_2, X87, AESNI, AVX, BMI2, ADX])
                  && x64Compatible d
 
 addOpcode :: MonadState Def m => Word8 -> m ()

--- a/src/Flexdis86/OpTable.hs
+++ b/src/Flexdis86/OpTable.hs
@@ -545,7 +545,7 @@ defOperands = lens _defOperands (\s v -> s { _defOperands = v })
 -- | Return true if this definition is one supported by flexdis86.
 defSupported :: Def -> Bool
 defSupported d = d^.reqAddrSize /= Just Size16
-                 && (d^.defCPUReq `elem` [Base, SSE, SSE2, SSE3, SSE4_1, SSE4_2, X87, AVX, BMI2, ADX])
+                 && (d^.defCPUReq `elem` [Base, SSE, SSE2, SSE3, SSE4_1, SSE4_2, X87, AESNI, AVX, BMI2, ADX])
                  && x64Compatible d
 
 addOpcode :: MonadState Def m => Word8 -> m ()


### PR DESCRIPTION
Specifically: `vpaddb`, `vpaddq`, `vxorps`, and `vpunpckhqdq`.

We also enable the `SSE3_atom` instructions (only `movbe`, as far as I know).