### PR TITLE
Fix decoding for vmovq

### DIFF
--- a/data/optable.xml
+++ b/data/optable.xml
@@ -4802,11 +4802,11 @@
       <class>avx</class>
       <def>
         <opc>/vex=128.F3.0F.WIG 7E</opc>
-        <opr>V W</opr>
+        <opr>V MqU</opr>
       </def>
       <def>
         <opc>/vex=128.66.0F.WIG D6</opc>
-        <opr>W V</opr>
+        <opr>MqU V</opr>
       </def>
     </instruction>
 


### PR DESCRIPTION
(For reference: https://www.felixcloutier.com/x86/movq)

When `vmovq` has a memory location as an operand, it should read one quadword. The previous decoding translated memory operands as `Mem128`, causing the Macaw semantics to read 128 bits from memory instead of 64.