### PR TITLE
Various assembler fixes

### DIFF
--- a/data/optable.xml
+++ b/data/optable.xml
@@ -4838,7 +4838,7 @@
         <class>sse</class>
         <def>
             <pfx>aso rexr rexx rexb</pfx>
-            <opc>0f 16 /mod=!11</opc>
+            <opc>0f 16</opc>
             <opr>V Mq</opr>
         </def>
         <def>

--- a/src/Flexdis86/Assembler.hs
+++ b/src/Flexdis86/Assembler.hs
@@ -626,8 +626,13 @@ encodeValue v =
     DWordReg (Reg32 rno) -> return (0x7 .&. rno)
     QWordReg (Reg64 rno) -> return (0x7 .&. rno)
     X87Register rno -> return (0x7 .&. fromIntegral rno)
-    MMXReg (MMXR rno) -> return rno
-    XMMReg (XMMR rno) -> return rno
+
+    -- NOTE: While there are more than 8 registers in both of these classes, the
+    -- extra bit (if required, to denote the registers 8-15) is provided by the
+    -- REX prefix byte and is not encoded here.
+    MMXReg (MMXR rno) -> return (0x7 .&. rno)
+    XMMReg (XMMR rno) -> return (0x7 .&. rno)
+
     _ | Just comps <- memRefComponents v ->
         case comps of
           -- We just need to mask some bits off of the reg64 numbers

--- a/tests/Roundtrip.hs
+++ b/tests/Roundtrip.hs
@@ -267,6 +267,8 @@ mmxOperandOpcodes = [ ("Load a value into an mmx register", ["movq (%eax), %mm2"
                     , ("mmx xor (mem -> reg)", ["pxor (%rcx), %mm4"])
                     , ("movaps %xmm4,0x90(%rsp)", ["movaps %xmm4,0x90(%rsp)"])
                     , ("movdqa %xmm14,%xmm12", ["movdqa %xmm14,%xmm12"])
+                    , ("movhps -0x150(%rbp),%xmm0", ["movhps -0x150(%rbp),%xmm0"])
+                    , ("movhps 0x8(%rsp),%xmm0", ["movhps 0x8(%rsp),%xmm0"])
                     ]
 
 sseTests :: T.TestTree

--- a/tests/Roundtrip.hs
+++ b/tests/Roundtrip.hs
@@ -266,6 +266,7 @@ mmxOperandOpcodes = [ ("Load a value into an mmx register", ["movq (%eax), %mm2"
                     , ("mmx xor (reg -> reg)", ["pxor %mm3, %mm0"])
                     , ("mmx xor (mem -> reg)", ["pxor (%rcx), %mm4"])
                     , ("movaps %xmm4,0x90(%rsp)", ["movaps %xmm4,0x90(%rsp)"])
+                    , ("movdqa %xmm14,%xmm12", ["movdqa %xmm14,%xmm12"])
                     ]
 
 sseTests :: T.TestTree


### PR DESCRIPTION
Fixes for assembly of some XMM registers and the `movhps` instruction