### PR TITLE
Sign-extend immediate operands in `push`

### DIFF
--- a/data/optable.xml
+++ b/data/optable.xml
@@ -6982,7 +6982,7 @@
         <def>
             <pfx>oso</pfx>
             <opc>68</opc>
-            <opr>Iz</opr>
+            <opr>sIz</opr>
             <mode>def64</mode>
         </def>
         <def>
@@ -6994,7 +6994,7 @@
         <def>
             <pfx>oso</pfx>
             <opc>6a</opc>
-            <opr>Ib</opr>
+            <opr>sIb</opr>
             <mode>def64</mode>
         </def>
     </instruction>


### PR DESCRIPTION
As noted in #35, immediate operands in `push` should be sign-extended if the immediate is of a size less than the operand size. In `flexdis86`, we can encode this by using the appropriate sign-extended `Value` constructors. This amounts to a couple of minor tweaks in `data/optable.xml`. I have also made a first attempt at making `mkInstruction` infer whether operand-size overrides are used, which is necessary in order to make the test suite pass.