### PR TITLE
add ASO prefix to E8 call opcode

### DIFF
--- a/data/optable.xml
+++ b/data/optable.xml
@@ -483,7 +483,14 @@
             <opr>Fv</opr>
         </def>
         <def>
-            <pfx>oso</pfx>
+            <!--
+                NOTE: We add the `aso` prefix to call as we found it in use in
+                binaries.  See for instance this discussion:
+                https://reviews.llvm.org/D120592#3348274
+                where the redundant ASO prefix is used to mimic a NOP; CALL
+                sequence in one instruction.
+            -->
+            <pfx>aso oso</pfx>
             <opc>e8</opc>
             <opr>Jz</opr>
             <mode>def64</mode>


### PR DESCRIPTION
While the specification seems to imply that this is reserved and unspecified, there is a compiler out there producing binaries where `67 e8` is used, supposedly as a means to alignment, as the prefix ought to have no effect on this instruction.

Kind of want to open this to discussion: do we want flexdis86 to be somewhat lax with the specification, recognizing binaries that compilers produce even when they use somewhat under-specified corners of the ISA semantics, or do we want to be stringent and reject such binaries?