### PR TITLE
add notrack support

### DIFF
--- a/data/optable.xml
+++ b/data/optable.xml
@@ -18,6 +18,9 @@
       pfx describes the prefixes that can precede the main opcode without
       turning it into a different instruction.  These may be:
       aso - accepts address size override
+      notrack - circumvent Indirect Branch Tracking (IBT), part of Intel's
+        control-flow enforcement technology (CET), see e.g.
+        https://software.intel.com/sites/default/files/managed/4d/2a/control-flow-enforcement-technology-preview.pdf
       oso - accepts operand size override
       rexw, rexr, rexx, rexb - uses the indicated REX bit
       seg - accepts a segment override
@@ -467,18 +470,18 @@
     <instruction>
         <mnemonic>call</mnemonic>
         <def>
-            <pfx>aso oso rexw rexr rexx rexb</pfx>
+            <pfx>aso notrack oso rexw rexr rexx rexb</pfx>
             <opc>ff /reg=2 /m=!64</opc>
             <opr>Ev</opr>
         </def>
         <def>
-            <pfx>aso oso rexw rexr rexx rexb</pfx>
+            <pfx>aso notrack oso rexw rexr rexx rexb</pfx>
             <opc>ff /reg=2 /m=64</opc>
             <opr>Eq</opr>
             <mode>def64</mode>
         </def>
         <def>
-            <pfx>aso oso rexw rexr rexx rexb</pfx>
+            <pfx>aso notrack oso rexw rexr rexx rexb</pfx>
             <opc>ff /reg=3</opc>
             <opr>Fv</opr>
         </def>
@@ -4191,13 +4194,13 @@
     <instruction>
         <mnemonic>jmp</mnemonic>
         <def>
-            <pfx>aso oso repnz rexw rexr rexx rexb</pfx>
+            <pfx>aso notrack oso repnz rexw rexr rexx rexb</pfx>
             <opc>ff /reg=4</opc>
             <opr>Ev</opr>
             <mode>def64</mode>
         </def>
         <def>
-            <pfx>aso oso repnz rexw rexr rexx rexb</pfx>
+            <pfx>aso notrack oso repnz rexw rexr rexx rexb</pfx>
             <opc>ff /reg=5</opc>
             <opr>Fv</opr>
         </def>

--- a/src/Flexdis86/Assembler.hs
+++ b/src/Flexdis86/Assembler.hs
@@ -92,6 +92,7 @@ findEncoding args def = do
   F.forM_ argTypes $ \at -> guard (matchOperandType oso at)
   let rex = mkREX argTypes
   let vex = Nothing -- XXX: implement this
+  let notrack = False -- for now, not trying to use this feature
   return $ II { iiLockPrefix = NoLockPrefix
               -- ???: why is this always Size16? Can we do better
               -- based on args or def?
@@ -104,6 +105,7 @@ findEncoding args def = do
                                       , _prVEX = vex
                                       , _prASO = aso
                                       , _prOSO = oso
+                                      , _prNoTrack = notrack
                                       }
               , iiRequiredPrefix = L.view requiredPrefix def
               , iiOpcode      = L.view defOpcodes  def

--- a/src/Flexdis86/Prefixes.hs
+++ b/src/Flexdis86/Prefixes.hs
@@ -21,6 +21,7 @@ module Flexdis86.Prefixes
   , prVEX
   , prASO
   , prOSO
+  , prNoTrack
   , prAddrSize
   , no_seg_prefix
   , setDefault
@@ -140,6 +141,7 @@ data Prefixes = Prefixes { _prLockPrefix :: !LockPrefix
                          , _prVEX :: !(Maybe VEX)
                          , _prASO :: !Bool
                          , _prOSO :: !Bool
+                         , _prNoTrack :: !Bool
                          }
                 deriving (Eq, Generic, Show)
 
@@ -207,6 +209,9 @@ prASO = lens _prASO (\s v -> s { _prASO = v })
 
 prOSO :: Lens' Prefixes Bool
 prOSO = lens _prOSO (\s v -> s { _prOSO = v })
+
+prNoTrack :: Lens' Prefixes Bool
+prNoTrack = lens _prNoTrack (\s v -> s { _prNoTrack = v })
 
 prAddrSize :: Prefixes -> SizeConstraint
 prAddrSize pfx | pfx^.prASO = Size32


### PR DESCRIPTION
This adds support for recognizing and flagging `notrack` on near jumps and calls.

It makes no attempt at introducing `notrack` when reassembling.