### PR TITLE
add ppInstructionAsShowS

### DIFF
--- a/src/Flexdis86/InstructionSet.hs
+++ b/src/Flexdis86/InstructionSet.hs
@@ -11,6 +11,7 @@ module Flexdis86.InstructionSet
     InstructionInstance
   , InstructionInstanceF(..)
   , ppInstruction
+  , ppInstructionAsShowS
   , ppInstructionWith
   , Value(..)
   , ppValue
@@ -293,6 +294,11 @@ ppInstruction i =
             (_,  NoLockPrefix) -> text (padToWidth 6 op) <+> ppPunctuate comma (ppValue <$> args)
             ([], _) -> sLockPrefix <+> text op
             (_,_)   -> sLockPrefix <+> text op <+> ppPunctuate comma (ppValue <$> args)
+
+-- | Allows libraries using `ppInstruction` to not have to depend on deprecated
+-- ansi-wl-pprint to turn instructions into `String`s.
+ppInstructionAsShowS :: InstructionInstance -> ShowS
+ppInstructionAsShowS = displayS . renderCompact . ppInstruction
 
 ppInstructionWith :: (a -> Doc)
                   -> InstructionInstanceF a


### PR DESCRIPTION
As a client of `flexdis86` as a library, I don't want to have to import and use deprecated functions to render instructions as strings.

This exposed helper makes it so that we're only seeing `String`-like types from the outside when calling `ppInstructionAsShowS`.