### PR TITLE
Import `Data.List` qualified, use `nubOrd` instead of `nub`

### DIFF
--- a/flexdis86.cabal
+++ b/flexdis86.cabal
@@ -16,7 +16,7 @@ library
     binary-symbols,
     binary,
     bytestring,
-    containers,
+    containers >= 0.6.0.1,
     deepseq,
     directory,
     exceptions >= 0.4 && < 0.11,


### PR DESCRIPTION
GHC has begun to emit warnings for unqualified `Data.List` imports. Also, `nub` is slow.