### PR TITLE
Parse XML at compile time

### DIFF
--- a/flexdis86.cabal
+++ b/flexdis86.cabal
@@ -69,7 +69,7 @@ test-suite flexdis86-tests
   hs-source-dirs:
     tests
 
-  ghc-options: -Wall
+  ghc-options: -Wall -rtsopts
 
   build-depends: flexdis86,
                  base,

--- a/flexdis86.cabal
+++ b/flexdis86.cabal
@@ -24,7 +24,6 @@ library
     microlens,
     microlens-mtl,
     mtl,
-    th-lift-instances,
     prettyprinter,
     template-haskell,
     unordered-containers,
@@ -50,7 +49,7 @@ library
     Flexdis86.OpTable
     Flexdis86.OpTable.Parse
     Flexdis86.Trie
-  ghc-options: -Wall -fno-ignore-asserts -O2
+  ghc-options: -Wall -fno-ignore-asserts -O2 -Wno-trustworthy-safe
 
 executable DumpInstr
   default-language: Haskell2010

--- a/flexdis86.cabal
+++ b/flexdis86.cabal
@@ -48,6 +48,7 @@ library
     Flexdis86.DefaultParser
     Flexdis86.Disassembler
     Flexdis86.OpTable
+    Flexdis86.OpTable.Parse
     Flexdis86.Trie
   ghc-options: -Wall -fno-ignore-asserts -O2
 

--- a/flexdis86.cabal
+++ b/flexdis86.cabal
@@ -24,6 +24,7 @@ library
     microlens,
     microlens-mtl,
     mtl,
+    th-lift-instances,
     prettyprinter,
     template-haskell,
     unordered-containers,

--- a/scripts/compare.py
+++ b/scripts/compare.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""Compare flexdis86 build/test metrics between two git refs.
+
+Usage:
+    python3 scripts/compare.py [ref1 [ref2]]
+
+Defaults to HEAD~1 vs HEAD.  Each stats comparison should be
+between the previous commit (HEAD~1) and the current one (HEAD).
+
+Output is a pair of Markdown tables:
+  1. Build & artifact sizes (build time, peak GHC heap RSS, .a/.so/test-binary sizes)
+  2. Test suite GHC RTS stats (heap allocated, max live, GC CPU time, total CPU time)
+
+All metrics are collected at -O0, -O1, and -O2.
+
+Requirements:
+  - cabal and ghc on PATH
+  - GNU time or /usr/bin/time (optional, used only as fallback)
+  - The test suite binary must be built with -rtsopts (or the default
+    -rtsopts=some) for test-suite stats to be collected.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+OPT_LEVELS = [0, 1, 2]
+
+
+# ── subprocess helpers ────────────────────────────────────────────────────────
+
+def run(cmd, cwd=None, capture=True, timeout=900, check=False):
+    """Run a shell command, optionally capturing merged stdout+stderr."""
+    kw = dict(shell=True, cwd=cwd, text=True, timeout=timeout)
+    if capture:
+        kw.update(stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    r = subprocess.run(cmd, **kw)
+    if check and r.returncode != 0:
+        raise subprocess.CalledProcessError(
+            r.returncode, cmd, getattr(r, 'stdout', None))
+    return r
+
+
+def git(cmd, cwd):
+    return run(f"git {cmd}", cwd=cwd, check=True)
+
+
+# ── git worktree helpers ──────────────────────────────────────────────────────
+
+def add_worktree(repo, path, ref):
+    git(f"worktree add --detach {path} {ref}", repo)
+    # Initialize submodules so local packages (e.g. deps/elf-edit) are available
+    run("git submodule update --init --recursive", cwd=path, check=True)
+    # Copy untracked cabal.project if present (needed for multi-package builds)
+    src = os.path.join(repo, 'cabal.project')
+    if os.path.exists(src):
+        import shutil
+        shutil.copy2(src, os.path.join(path, 'cabal.project'))
+
+
+def remove_worktree(repo, path):
+    run(f"git worktree remove --force {path}", cwd=repo)
+
+
+# ── GHC RTS stats parsers ─────────────────────────────────────────────────────
+
+def parse_build_rts(text):
+    """From the merged output of a 'cabal build' that was run with
+    --ghc-options='+RTS -s -RTS', return the peak Maximum residency
+    (in bytes) across all GHC module-compilation invocations."""
+    max_res = 0
+    # GHC +RTS -s output line:
+    #   123,456 bytes maximum residency (N sample(s))
+    for m in re.finditer(r'([\d,]+)\s+bytes maximum residency', text):
+        val = int(m.group(1).replace(',', ''))
+        max_res = max(max_res, val)
+    return max_res or None
+
+
+def parse_test_rts(text):
+    """Parse GHC +RTS -s output from a test-binary run.
+
+    Returns a dict with keys:
+        heap_allocated   – total bytes allocated in the heap
+        max_live         – maximum residency (bytes)
+        gc_cpu           – GC CPU time (seconds)
+        total_cpu        – total CPU time (seconds)
+    Missing fields are None.
+    """
+    def find(pat):
+        m = re.search(pat, text, re.MULTILINE)
+        return m.group(1) if m else None
+
+    def inum(s):
+        return int(s.replace(',', '')) if s else None
+
+    def fnum(s):
+        return float(s) if s else None
+
+    return {
+        'heap_allocated': inum(find(r'([\d,]+)\s+bytes allocated in the heap')),
+        'max_live':       inum(find(r'([\d,]+)\s+bytes maximum residency')),
+        'gc_cpu':         fnum(find(r'GC\s+time\s+([\d.]+)s')),
+        'total_cpu':      fnum(find(r'Total\s+time\s+([\d.]+)s')),
+    }
+
+
+# ── artifact-size helpers ─────────────────────────────────────────────────────
+
+def artifact_sizes(worktree):
+    """Return a dict with keys static_a, shared_so, test_bin (bytes).
+    Keys are absent when the corresponding file was not found."""
+    d = Path(worktree) / 'dist-newstyle'
+    if not d.exists():
+        return {}
+    sizes = {}
+
+    # Static library: largest .a file whose name contains 'flexdis86'
+    # (but not the test binary helper libs).
+    a_files = [
+        f for f in d.rglob('*.a')
+        if 'flexdis86' in f.name
+        and 'test' not in f.stem.lower()
+        and f.stat().st_size > 0
+    ]
+    if a_files:
+        sizes['static_a'] = max(f.stat().st_size for f in a_files)
+
+    # Shared library (.so on Linux, .dylib on macOS)
+    so_files = [
+        f for f in list(d.rglob('*.so')) + list(d.rglob('*.dylib'))
+        if 'flexdis86' in f.name and f.stat().st_size > 0
+    ]
+    if so_files:
+        sizes['shared_so'] = max(f.stat().st_size for f in so_files)
+
+    # Test binary
+    tb = [
+        f for f in d.rglob('flexdis86-tests')
+        if f.is_file() and os.access(f, os.X_OK)
+    ]
+    if tb:
+        sizes['test_bin'] = max(f.stat().st_size for f in tb)
+
+    return sizes
+
+
+# ── per-ref / per-opt measurement ─────────────────────────────────────────────
+
+def _write_project_local(worktree, opt):
+    """Append opt-level + GHC RTS stat flags for flexdis86 to
+    cabal.project.local, returning the original content for later restore."""
+    p = Path(worktree) / 'cabal.project.local'
+    original = p.read_text() if p.exists() else ''
+    addition = (
+        f'\n-- injected by compare.py\n'
+        f'package flexdis86\n'
+        f'  ghc-options: -O{opt} +RTS -s -RTS\n'
+    )
+    p.write_text(original + addition)
+    return original
+
+
+def _restore_project_local(worktree, original):
+    p = Path(worktree) / 'cabal.project.local'
+    if original:
+        p.write_text(original)
+    else:
+        p.unlink(missing_ok=True)
+
+
+def measure_build(worktree, opt):
+    """Build the project at the given opt level.
+
+    Returns a dict with keys:
+        build_time   – wall-clock seconds for 'cabal build all'
+        peak_rss     – peak Maximum residency across all GHC invocations (bytes)
+        static_a     – static library size (bytes), if found
+        shared_so    – shared library size (bytes), if found
+        test_bin     – test binary size (bytes), if found
+    Returns None on build failure.
+    """
+    run('cabal clean', cwd=worktree)
+    original = _write_project_local(worktree, opt)
+    try:
+        t0 = time.monotonic()
+        r = run('cabal build all', cwd=worktree, timeout=900)
+        elapsed = time.monotonic() - t0
+    finally:
+        _restore_project_local(worktree, original)
+
+    if r.returncode != 0:
+        print(f'  build -O{opt} FAILED:\n{r.stdout[-3000:]}', file=sys.stderr)
+        return None
+
+    m = {'build_time': elapsed}
+    rss = parse_build_rts(r.stdout)
+    if rss is not None:
+        m['peak_rss'] = rss
+    m.update(artifact_sizes(worktree))
+    return m
+
+
+def measure_test(worktree, opt):
+    """Run the test suite with +RTS -s and return parsed stats (dict).
+
+    The test binary must be compiled with -rtsopts (or the default
+    -rtsopts=some, which allows -s) for RTS stats to be collected.
+    An empty dict is returned on failure or if stats are unavailable.
+    """
+    r = run(
+        'cabal test flexdis86-tests --test-options="+RTS -s -RTS"',
+        cwd=worktree, timeout=600
+    )
+    if r.returncode != 0:
+        print(f'  test -O{opt} FAILED', file=sys.stderr)
+        return {}
+    return parse_test_rts(r.stdout)
+
+
+# ── formatting helpers ────────────────────────────────────────────────────────
+
+def fmt_mb(n):
+    if n is None:
+        return 'N/A'
+    if n >= 1_000_000_000:
+        return f'{n / 1e9:.2f} GB'
+    return f'{n / 1e6:.1f} MB'
+
+
+def fmt_sec(s):
+    return f'{s:.3f}s' if s is not None else 'N/A'
+
+
+def fmt_change(a, b):
+    if a is None or b is None or a == 0:
+        return 'N/A'
+    pct = (b - a) / a * 100
+    arrow = '▲' if pct >= 0 else '▼'
+    return f'{arrow}{pct:+.1f}%'
+
+
+def md_table(caption, rows):
+    """Render a Markdown table.  rows[0] is the header row."""
+    widths = [
+        max(len(str(rows[r][c])) for r in range(len(rows)))
+        for c in range(len(rows[0]))
+    ]
+
+    def fmt_row(cells):
+        return '| ' + ' | '.join(
+            str(c).ljust(widths[i]) for i, c in enumerate(cells)
+        ) + ' |'
+
+    sep = '|' + '|'.join('-' + '-' * w + '-' for w in widths) + '|'
+    lines = [f'## {caption}', '', fmt_row(rows[0]), sep]
+    for row in rows[1:]:
+        lines.append(fmt_row(row))
+    return '\n'.join(lines)
+
+
+# ── main ──────────────────────────────────────────────────────────────────────
+
+def main():
+    ap = argparse.ArgumentParser(
+        description='Compare flexdis86 build/test metrics between two git refs.',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog='Defaults to HEAD~1 vs HEAD.',
+    )
+    ap.add_argument('ref1', nargs='?', default='HEAD~1',
+                    help='baseline ref (default: HEAD~1)')
+    ap.add_argument('ref2', nargs='?', default='HEAD',
+                    help='comparison ref (default: HEAD)')
+    ap.add_argument('--repo', default='.',
+                    help='repository root (default: current directory)')
+    args = ap.parse_args()
+
+    repo = os.path.abspath(args.repo)
+    r1, r2 = args.ref1, args.ref2
+
+    def resolve(ref):
+        return run(f'git rev-parse --short {ref}', cwd=repo,
+                   check=True).stdout.strip()
+
+    h1, h2 = resolve(r1), resolve(r2)
+    lbl1 = f'`{r1}` ({h1})'
+    lbl2 = f'`{r2}` ({h2})'
+    print(f'Comparing {lbl1}  vs  {lbl2}', file=sys.stderr)
+
+    data = {r1: {}, r2: {}}
+
+    with tempfile.TemporaryDirectory(prefix='flexdis86-cmp-') as tmp:
+        wt = {}
+        try:
+            for ref in (r1, r2):
+                path = os.path.join(
+                    tmp,
+                    ref.replace('/', '_').replace('~', '_').replace('^', '_')
+                )
+                print(f'\nCreating worktree for {ref} ...', file=sys.stderr)
+                add_worktree(repo, path, ref)
+                wt[ref] = path
+
+            for ref, path in wt.items():
+                for opt in OPT_LEVELS:
+                    print(f'\n=== {ref}  -O{opt} ===', file=sys.stderr)
+
+                    print(f'  building...', file=sys.stderr)
+                    bm = measure_build(path, opt)
+
+                    print(f'  testing...', file=sys.stderr)
+                    tm = measure_test(path, opt)
+
+                    if bm is not None:
+                        data[ref][opt] = {
+                            **bm,
+                            **{'t_' + k: v for k, v in tm.items()},
+                        }
+
+        finally:
+            for ref, path in wt.items():
+                try:
+                    remove_worktree(repo, path)
+                except Exception as e:
+                    print(f'Warning: failed to remove worktree {path}: {e}',
+                          file=sys.stderr)
+
+    hdr = ['Metric', 'Opt', lbl1, lbl2, 'Change']
+
+    # ── Build & artifact-sizes table ──────────────────────────────────────
+    build_rows = [hdr]
+    build_metrics = [
+        ('Build time',        'build_time', fmt_sec),
+        ('Peak GHC heap RSS', 'peak_rss',   fmt_mb),
+        ('Static lib (.a)',   'static_a',   fmt_mb),
+        ('Shared lib (.so)',  'shared_so',  fmt_mb),
+        ('Test binary',       'test_bin',   fmt_mb),
+    ]
+    for label, key, fmt in build_metrics:
+        for opt in OPT_LEVELS:
+            v1 = data[r1].get(opt, {}).get(key)
+            v2 = data[r2].get(opt, {}).get(key)
+            build_rows.append(
+                [label, f'`-O{opt}`', fmt(v1), fmt(v2), fmt_change(v1, v2)]
+            )
+
+    # ── Test-suite RTS-stats table ────────────────────────────────────────
+    test_rows = [hdr]
+    test_metrics = [
+        ('Heap allocated', 't_heap_allocated', fmt_mb),
+        ('Max live bytes', 't_max_live',        fmt_mb),
+        ('GC CPU time',    't_gc_cpu',          fmt_sec),
+        ('Total CPU time', 't_total_cpu',       fmt_sec),
+    ]
+    for label, key, fmt in test_metrics:
+        for opt in OPT_LEVELS:
+            v1 = data[r1].get(opt, {}).get(key)
+            v2 = data[r2].get(opt, {}).get(key)
+            test_rows.append(
+                [label, f'`-O{opt}`', fmt(v1), fmt(v2), fmt_change(v1, v2)]
+            )
+
+    print(md_table('Build & artifact sizes', build_rows))
+    print()
+    print(md_table('Test suite (GHC RTS stats, deterministic)', test_rows))
+
+
+if __name__ == '__main__':
+    main()

--- a/src/Flexdis86/Assembler.hs
+++ b/src/Flexdis86/Assembler.hs
@@ -54,8 +54,10 @@ data AssemblerContext =
                    }
   deriving (Show)
 
-mkX64Assembler :: B.ByteString -> Either String AssemblerContext
-mkX64Assembler bs = (assemblerContext . filter defSupported) <$> parseOpTable bs
+-- | Build an 'AssemblerContext' from a list of pre-parsed 'Def's. The caller is
+-- responsible for providing only supported defs (see @defSupported@).
+mkX64Assembler :: [Def] -> AssemblerContext
+mkX64Assembler = assemblerContext
 
 -- Warning: some instructions, e.g. @xor <64-bit reg> <64-bit reg>@,
 -- have multiple encodings. The order we fold defs here, i.e. 'foldr'

--- a/src/Flexdis86/DefaultParser.hs
+++ b/src/Flexdis86/DefaultParser.hs
@@ -7,7 +7,7 @@ Defines the default parser from optable.xml as compiled in.
 -}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE Trustworthy#-}
+{-# LANGUAGE Trustworthy #-}
 module Flexdis86.DefaultParser
   ( defaultX64Disassembler
   , defaultX64Assembler
@@ -15,61 +15,52 @@ module Flexdis86.DefaultParser
 
 import           Control.Monad (when)
 import qualified Data.ByteString as BS
-import           Data.ByteString.Unsafe (unsafePackAddressLen)
-import           Language.Haskell.TH.Syntax
+import           Instances.TH.Lift ()
+import           Language.Haskell.TH.Syntax (lift, qAddDependentFile, qRunIO)
 import qualified System.Directory as D
 import qualified System.FilePath as F
-import           System.IO.Unsafe (unsafePerformIO)
 
 import           Flexdis86.Assembler
 import           Flexdis86.Disassembler
+import           Flexdis86.OpTable
 
-{-# NOINLINE optableData #-}
-
--- | A bytestring containing the compiled XML optable specification.
-optableData :: BS.ByteString
-optableData =
+-- | The instruction definitions parsed from @optable.xml@ at compile time.
+-- Only definitions supported by flexdis86 are included (see 'defSupported').
+optableDefs :: [Def]
+optableDefs =
  -- The @getPathToOptableXML@ computes an absolute path to the XML
  -- file. This is helpful in case our current working directory is not
  -- the directory containing the @flexdis86.cabal@ file. This happens,
  -- e.g., when we build flexdis86 as a dependency of another package
  -- in Emacs @haskell-mode@.
- ($(do let getPathToOptableXML :: IO FilePath
-           getPathToOptableXML = do
-             let relativePath = "data/optable.xml"
-             absPathToThisFile <- D.makeAbsolute __FILE__
-             let absolutePath =
-                   -- Remove 'src/Flexdis86/DefaultParser.hs' and add
-                   -- 'data/optable.xml'.
-                   (F.takeDirectory . F.takeDirectory . F.takeDirectory $
-                    absPathToThisFile) F.</> relativePath
-             exists <- D.doesFileExist absolutePath
-             when (not exists) $
-               error $ "Can't find \"data/optable.xml\"! Tried " ++
-                       absolutePath
-             return absolutePath
+ $(do let getPathToOptableXML :: IO FilePath
+          getPathToOptableXML = do
+            let relativePath = "data/optable.xml"
+            absPathToThisFile <- D.makeAbsolute __FILE__
+            let absolutePath =
+                  -- Remove 'src/Flexdis86/DefaultParser.hs' and add
+                  -- 'data/optable.xml'.
+                  (F.takeDirectory . F.takeDirectory . F.takeDirectory $
+                   absPathToThisFile) F.</> relativePath
+            exists <- D.doesFileExist absolutePath
+            when (not exists) $
+              error $ "Can't find \"data/optable.xml\"! Tried " ++
+                      absolutePath
+            return absolutePath
 
-       path <- qRunIO getPathToOptableXML
-       qAddDependentFile path
-       contents <- qRunIO $ BS.readFile path
-       let blen :: Int
-           blen = fromIntegral (BS.length contents)
-#if MIN_VERSION_template_haskell(2,8,0)
-       let addr = LitE $ StringPrimL $ BS.unpack contents
-#else
-       let addr = LitE $ StringPrimL $ UTF8.toString contents
-#endif
-       [| unsafePerformIO $ unsafePackAddressLen blen $(return addr) |]))
+      path <- qRunIO getPathToOptableXML
+      qAddDependentFile path
+      contents <- qRunIO $ BS.readFile path
+      case parseOpTable contents of
+        Left e    -> error ("optableDefs: failed to parse optable.xml: " ++ e)
+        Right defs -> lift defs)
 
 
 defaultX64Disassembler :: NextOpcodeTable
 defaultX64Disassembler = p
-  where p = case mkX64Disassembler optableData of
+  where p = case mkX64Disassembler optableDefs of
               Right v -> v
-              Left  s -> error ("defaultX64Diassembler: " ++ s)
+              Left  s -> error ("defaultX64Disassembler: " ++ s)
 
 defaultX64Assembler :: AssemblerContext
-defaultX64Assembler =
-  case mkX64Assembler optableData of
-    Right c -> c
-    Left err -> error ("defaultX64Assembler: " ++ err)
+defaultX64Assembler = mkX64Assembler optableDefs

--- a/src/Flexdis86/DefaultParser.hs
+++ b/src/Flexdis86/DefaultParser.hs
@@ -1,7 +1,7 @@
 {- |
 Module      :  $Header$
-Copyright   :  (c) 2013-2016 Galois, Inc
-Maintainer  :  jhendrix@galois.com
+Copyright   :  (c) Galois, Inc 2013-2026
+Maintainer  :  langston.barrett@gmail.com
 
 Defines the default parser from optable.xml as compiled in.
 -}
@@ -22,7 +22,8 @@ import qualified System.FilePath as F
 
 import           Flexdis86.Assembler
 import           Flexdis86.Disassembler
-import           Flexdis86.OpTable
+import           Flexdis86.OpTable (Def)
+import           Flexdis86.OpTable.Parse (parseOpTable)
 
 -- | The instruction definitions parsed from @optable.xml@ at compile time.
 -- Only definitions supported by flexdis86 are included (see 'defSupported').

--- a/src/Flexdis86/DefaultParser.hs
+++ b/src/Flexdis86/DefaultParser.hs
@@ -14,21 +14,34 @@ module Flexdis86.DefaultParser
   ) where
 
 import           Control.Monad (when)
+import qualified Data.Binary as Bin
 import qualified Data.ByteString as BS
-import           Instances.TH.Lift ()
-import           Language.Haskell.TH.Syntax (lift, qAddDependentFile, qRunIO)
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.ByteString.Unsafe as BSU
+import           Language.Haskell.TH.Syntax (Exp(..), Lit(..), qAddDependentFile, qRunIO)
 import qualified System.Directory as D
 import qualified System.FilePath as F
+import           System.IO.Unsafe (unsafePerformIO)
 
 import           Flexdis86.Assembler
 import           Flexdis86.Disassembler
 import           Flexdis86.OpTable (Def)
 import           Flexdis86.OpTable.Parse (parseOpTable)
 
--- | The instruction definitions parsed from @optable.xml@ at compile time.
--- Only definitions supported by flexdis86 are included (see 'defSupported').
-optableDefs :: [Def]
-optableDefs =
+-- | The instruction definitions parsed from @optable.xml@ at compile time,
+-- serialized via 'Data.Binary' and embedded as a single @Addr#@ string
+-- literal ('StringPrimL').
+--
+-- This is Pareto-optimal among compile-time embedding strategies, when
+-- considering trade-offs including compile time, compiler memory usage,
+-- runtime, and artifact size. Alternatives considered:
+--
+-- * Embedding the XML file: requires otherwise-unnecessary runtime XML parsing
+-- * Running @mkOpcodeTable@ in TH: OOMs due to construction of huge trie
+-- * @Lift@ing the @Def@s: huge artifacts due to one relocation per ADT field
+optableBytes :: BS.ByteString
+{-# NOINLINE optableBytes #-}
+optableBytes =
  -- The @getPathToOptableXML@ computes an absolute path to the XML
  -- file. This is helpful in case our current working directory is not
  -- the directory containing the @flexdis86.cabal@ file. This happens,
@@ -52,10 +65,25 @@ optableDefs =
       path <- qRunIO getPathToOptableXML
       qAddDependentFile path
       contents <- qRunIO $ BS.readFile path
-      case parseOpTable contents of
-        Left e    -> error ("optableDefs: failed to parse optable.xml: " ++ e)
-        Right defs -> lift defs)
+      defs <- case parseOpTable contents of
+                Left  e -> fail ("optableBytes: failed to parse optable.xml: " ++ e)
+                Right d -> return d
+      let encoded = Bin.encode defs
+          n       = LBS.length encoded
+          ws      = LBS.unpack encoded
+      -- Emit: unsafePerformIO (BSU.unsafePackAddressLen n "\xNN..."#)
+      -- StringPrimL puts the bytes in .rodata as a single Addr# literal —
+      -- one blob, zero relocations.
+      return $
+        AppE (VarE 'unsafePerformIO) $
+        AppE (AppE (VarE 'BSU.unsafePackAddressLen)
+                   (LitE (IntegerL (fromIntegral n))))
+             (LitE (StringPrimL ws)))
 
+-- | Pre-parsed instruction definitions, decoded from the compile-time
+-- Binary blob at first use.
+optableDefs :: [Def]
+optableDefs = Bin.decode (LBS.fromStrict optableBytes)
 
 defaultX64Disassembler :: NextOpcodeTable
 defaultX64Disassembler = p

--- a/src/Flexdis86/DefaultParser.hs
+++ b/src/Flexdis86/DefaultParser.hs
@@ -15,6 +15,7 @@ module Flexdis86.DefaultParser
 
 import           Control.Monad (when)
 import qualified Data.Binary as Bin
+import           Data.Binary.Get (isEmpty, runGet)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString.Unsafe as BSU
@@ -65,12 +66,11 @@ optableBytes =
       path <- qRunIO getPathToOptableXML
       qAddDependentFile path
       contents <- qRunIO $ BS.readFile path
-      defs <- case parseOpTable contents of
-                Left  e -> fail ("optableBytes: failed to parse optable.xml: " ++ e)
-                Right d -> return d
-      let encoded = Bin.encode defs
-          n       = LBS.length encoded
-          ws      = LBS.unpack encoded
+      encoded <- case parseOpTable contents of
+                   Left  e -> fail ("optableBytes: failed to parse optable.xml: " ++ e)
+                   Right b -> return b
+      let n  = LBS.length encoded
+          ws = LBS.unpack encoded
       -- Emit: unsafePerformIO (BSU.unsafePackAddressLen n "\xNN..."#)
       -- StringPrimL puts the bytes in .rodata as a single Addr# literal —
       -- one blob, zero relocations.
@@ -83,7 +83,12 @@ optableBytes =
 -- | Pre-parsed instruction definitions, decoded from the compile-time
 -- Binary blob at first use.
 optableDefs :: [Def]
-optableDefs = Bin.decode (LBS.fromStrict optableBytes)
+optableDefs = runGet getDefs (LBS.fromStrict optableBytes)
+  where
+    getDefs = do
+      empty <- isEmpty
+      if empty then return []
+               else (:) <$> Bin.get <*> getDefs
 
 defaultX64Disassembler :: NextOpcodeTable
 defaultX64Disassembler = p

--- a/src/Flexdis86/DefaultParser.hs
+++ b/src/Flexdis86/DefaultParser.hs
@@ -1,7 +1,7 @@
 {- |
 Module      :  $Header$
 Copyright   :  (c) Galois, Inc 2013-2026
-Maintainer  :  langston.barrett@gmail.com
+Maintainer  :  langston@galois.com
 
 Defines the default parser from optable.xml as compiled in.
 -}

--- a/src/Flexdis86/Disassembler.hs
+++ b/src/Flexdis86/Disassembler.hs
@@ -1397,12 +1397,12 @@ opcodeTableSize (OpcodeTable (Trie.Leaf (OpcodeTableEntry defsWithModRM defsWith
 nextOpcodeSize :: NextOpcodeTable -> Int
 nextOpcodeSize v = sum (opcodeTableSize <$> v)
 
--- | Create an instruction parser from the given udis86 parser.
--- This is currently restricted to x64 base operations.
-mkX64Disassembler :: BS.ByteString -> Either String NextOpcodeTable
-mkX64Disassembler bs = do
-  tbl <- parseOpTable bs
-  OpcodeTable mOpTbl <- runParserGen $ mkOpcodeTable (filter defSupported tbl)
+-- | Create an instruction parser from a list of pre-parsed 'Def's.
+-- The caller is responsible for providing only supported defs (see
+-- 'defSupported' in "Flexdis86.OpTable").
+mkX64Disassembler :: [Def] -> Either String NextOpcodeTable
+mkX64Disassembler defs = do
+  OpcodeTable mOpTbl <- runParserGen $ mkOpcodeTable defs
   case mOpTbl of
     Trie.Branch v -> Right $! coerce v
     Trie.Leaf{} -> Left "Unexpected OpcodeTableEntry as a top-level disassemble result"

--- a/src/Flexdis86/OpTable.hs
+++ b/src/Flexdis86/OpTable.hs
@@ -1,32 +1,27 @@
 {- |
 Module      :  $Header$
-Copyright   :  (c) Galois, Inc 2013-2016
-Maintainer  :  jhendrix@galois.com
+Copyright   :  (c) Galois, Inc 2013-2026
+Maintainer  :  langston.barrett@gmail.com
 
-This declares the parser for optable.xml file, which is used to define the
-instruction set.
+Types describing x86 instruction definitions, and utilities for working
+with them at runtime.  XML parsing lives in "Flexdis86.OpTable.Parse".
 -}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveLift #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE PatternGuards #-}
 module Flexdis86.OpTable
-  ( -- * Primitive types.
-    CPURequirement(..)
+  ( -- * Primitive types
+    Mode(..)
+  , CPURequirement(..)
   , Vendor(..)
   , ModeLimit(..)
     -- * Def
-  , Def
+  , Def(..)
   , defMnemonic
   , defMnemonicSynonyms
   , defVendor
   , defCPUReq
   , modeLimit
   , defSupported
-  , Mode(..)
   , defMode
   , reqAddrSize
   , OperandSizeConstraint(..)
@@ -41,165 +36,32 @@ module Flexdis86.OpTable
   , defOperands
   , x64Compatible
   , vexPrefixes
-    -- * Parsing defs
-  , parseOpTable
+  , supportedCPUReqs
+    -- * Operand lookup
   , lookupOperandType
   ) where
 
 import qualified Control.DeepSeq as DS
 import qualified Control.Monad.Fail as MF
-import           Control.Monad (forM_, unless, when)
-import           Control.Monad.State (MonadState(..), execStateT, gets)
-import           Data.Bits ((.&.), (.|.), shiftR, shiftL)
+import           Data.Bits ((.&.))
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BSC
-import           Data.Char
-import           Data.Containers.ListUtils (nubOrd)
-import qualified Data.List as List
 import qualified Data.Map.Strict as Map
-import           Data.Maybe
-import           Data.Word
-import           GHC.Generics
+import           Data.Word (Word8)
+import           GHC.Generics (Generic)
 import           Instances.TH.Lift ()
 import           Language.Haskell.TH.Syntax (Lift)
 import           Lens.Micro (Lens', lens, (^.))
-import           Lens.Micro.Mtl ((%=), (.=), (?=), use)
-import           Numeric (readDec, readHex)
-import           Text.XML.Light
 
 import           Flexdis86.Operand
 import           Flexdis86.Register
 import           Flexdis86.Segment
 import           Flexdis86.Sizes
 
-qname :: String -> QName
-qname nm = QName { qName = nm, qURI = Nothing, qPrefix = Nothing }
-
-ppQName :: QName -> String
-ppQName qnm = qName qnm
-
-data ElemState = ElemState { esName :: QName
-                           , esContent :: [Content]
-                           , esLine :: Maybe Line
-                           }
-
-mkElemState :: Element -> ElemState
-mkElemState e = ElemState { esName = elName e
-                          , esContent = elContent e
-                          , esLine = elLine e
-                          }
-
-newtype ElemParser a = EP { unEP :: ElemState -> Either String (a,ElemState) }
-
-instance Functor ElemParser where
-  fmap f m = EP (\s -> case unEP m s of
-                         Left e -> Left e
-                         Right (v,s') -> Right (f v, s'))
-
-instance Applicative ElemParser where
-  pure v = EP $ \s -> Right (v,s)
-  m <*> h = EP $ \s -> do
-    (f,s1) <- unEP m s
-    (x,s2) <- unEP h s1
-    return (f x, s2)
-
-instance Monad ElemParser where
-  return = pure
-  m >>= h = EP $ \s -> do (v,s') <- unEP m s
-                          unEP (h v) s'
-#if !(MIN_VERSION_base(4,13,0))
-  fail = MF.fail
-#endif
-
-instance MF.MonadFail ElemParser where
-  fail e = EP $ \s -> Left $ show (esLine s) ++ ": " ++  e
-
-instance MonadState ElemState ElemParser where
-  get = EP (\s -> Right (s,s))
-  put v = EP (\_ -> Right ((),v))
-
-runWithElement :: ElemParser a -> Element -> ElemParser a
-runWithElement m e = do
-  s <- get
-  put (mkElemState e)
-  v <- m
-  put s
-  return v
-
-runElemParser :: ElemParser a -> Element -> Either String a
-runElemParser m e = fmap fst (unEP m (mkElemState e))
-
-checkTag :: String -> ElemParser ()
-checkTag nm = do
-  enm <- gets esName
-  when (enm /= qname nm) $
-    fail $ "Unexpected tag " ++ ppQName enm ++ " in element."
-
-getNextElt :: ElemParser (Maybe Element)
-getNextElt = do
-  s <- get
-  case esContent s of
-    [] -> return Nothing
-    (h:r) -> do
-      put s { esContent = r }
-      case h of
-        Elem e -> return (Just e)
-        Text d | dropWhile isSpace (cdData d) == "" -> getNextElt
-        t -> fail $ "Unexpected non-whitespace text: " ++ show t
-
-pushElt :: Element -> ElemParser ()
-pushElt e = do
-  s <- get
-  put s { esContent = Elem e : esContent s }
-
-next :: ElemParser a -> ElemParser a
-next p = do
-  me <- getNextElt
-  case me of
-    Just e -> runWithElement p e
-    Nothing -> fail "Failed to find next element."
-
-opt :: String -> ElemParser a -> ElemParser (Maybe a)
-opt nm p = do
-  me <- getNextElt
-  case me of
-    Nothing -> return Nothing
-    Just e
-      | elName e == qname nm ->
-        fmap Just $ runWithElement p e
-      | otherwise -> pushElt e >> return Nothing
-
-checkEnd :: ElemParser ()
-checkEnd = do
-  me <- getNextElt
-  case me of
-    Nothing -> return ()
-    Just e -> pushElt e >> fail "Expected end of elements."
-
-remainingElts :: ElemParser a -> ElemParser [a]
-remainingElts p = go []
-  where go r = do
-          me <- getNextElt
-          case me of
-            Nothing -> return (reverse r)
-            Just e -> do
-              v <- runWithElement p e
-              go (v:r)
-
-asText :: ElemParser String
-asText = do
-  s <- get
-  case esContent s of
-    [Text d] | cdVerbatim d == CDataText -> return (cdData d)
-    x -> fail (unlines [ "asText found non-text.", show x])
-
-required_text :: String -> ElemParser String
-required_text nm = next $ checkTag nm >> asText
-
 ------------------------------------------------------------------------
--- Misc
+-- Mode
 
--- | Mode effect on instruction semantecs.
+-- | Mode effect on instruction semantics.
 data Mode
      -- | Default operand size is 64 bits in x64 mode.
    = Default64
@@ -209,17 +71,10 @@ data Mode
 
 instance DS.NFData Mode
 
--- | Parse a mode for the instruction.
-parse_mode :: ElemParser (Maybe Mode)
-parse_mode = opt "mode" $ do
-  txt <- asText
-  case txt of
-    "def64" -> return Default64
-    "inv64" -> return Invalid64
-    _ -> fail $ "Invalid mode: " ++ show txt
+------------------------------------------------------------------------
+-- CPURequirement
 
--- | Defines which features are required for instruction
--- to be supported.
+-- | Defines which features are required for instruction to be supported.
 data CPURequirement
      -- | This is a base instruction.
    = Base
@@ -242,65 +97,24 @@ data CPURequirement
    | AESNI
      -- | SHA extension
    | SHA
-
    | AVX    -- ^ Advanced vector extensions
-
-   -- | Bit manipulation instructions
-   | BMI2
-
-   -- | Multi-precision add-carry instructions
-   | ADX
+   | BMI2   -- ^ Bit manipulation instructions
+   | ADX    -- ^ Multi-precision add-carry instructions
   deriving (Eq, Generic, Lift, Ord, Show)
 
 instance DS.NFData CPURequirement
 
-insClassMap :: Map.Map String CPURequirement
-insClassMap = Map.fromList
-  [ (,) "X87"   X87
-  , (,) "X87 UNDOC" X87_undocumented
-  , (,) "smx"   SMX
-  , (,) "sse"   SSE
-  , (,) "sse2"  SSE2
-  , (,) "sse3"   SSE3
-  , (,) "sse3 atom" SSE3_atom
-  , (,) "sse4.1" SSE4_1
-  , (,) "sse4.2" SSE4_2
-  , (,) "aesni" AESNI
-  , (,) "sha" SHA
-  , (,) "avx" AVX
-  , (,) "bmi2" BMI2
-  , (,) "adx" ADX
-  ]
+------------------------------------------------------------------------
+-- Vendor
 
--- | Returns a CPU requirement, possible given a requirement from the outer
--- constext.
-parse_CPURequirement :: CPURequirement -> ElemParser CPURequirement
-parse_CPURequirement c = do
-  fmap (fromMaybe c) $ opt "class" $ do
-    txt <- asText
-    case Map.lookup txt insClassMap of
-      Nothing -> fail $ "Unknown instruction class: " ++ show txt
-      Just v -> do
-        when (c /= Base) $ do
-          fail $ "Instruction class already defined " ++ show (c,v)
-        return v
-
--- | Defines whether instuction is vendor specific.
+-- | Defines whether instruction is vendor specific.
 data Vendor = AMD | Intel
   deriving (Eq, Generic, Lift, Ord, Show)
 
 instance DS.NFData Vendor
 
-parse_vendor :: Maybe Vendor -> ElemParser (Maybe Vendor)
-parse_vendor v = do
-  fmap (maybe v Just) $ opt "vendor" $ do
-    when (isJust v) $ do
-      fail $ "Vendor already defined."
-    txt <- asText
-    case txt of
-      "amd" -> return $ AMD
-      "intel" -> return $ Intel
-      _ -> fail $ "Unknown vendor: " ++ show txt
+------------------------------------------------------------------------
+-- ModeLimit
 
 -- | Indicates restrictions on which mode instruction may run in.
 data ModeLimit
@@ -315,143 +129,8 @@ instance DS.NFData ModeLimit
 valid64 :: ModeLimit -> Bool
 valid64 m = m == AnyMode || m == Only64
 
---------------------------------------------------------------------------------
-
--- | VEX prefixes
--- See "Intel® 64 and IA-32 Architectures Software Developer’s Manual"
--- Vol. 2A 3-3
-data VexSpec = VexSpec
-  { vexUseVVVV    :: Maybe VexUseVVVV   -- ^ Purpose of VVVV, if any.
-  , vexSize       :: VexSize            -- ^ Vector size
-  , vexImpSimd    :: Maybe VexImpSimd   -- ^ Implied SIMD prefix
-  , vexImpOpc     :: Maybe VexImpOpc    -- ^ Implided opcode prefix
-  , vexW          :: Maybe VexW         -- ^ W field
-  , vexAllowShort :: Bool               -- ^ Could we use 2-byte encoding
-  } deriving (Eq,Show)
-
-data VexUseVVVV = VEX_NDS | VEX_NDD | VEX_DDS      deriving (Eq,Show)
-data VexSize    = Vex128 | Vex256                  deriving (Eq,Show)
-data VexImpSimd = Imp0x66 | Imp0xF3 | Imp0xF2      deriving (Eq,Show)
-data VexImpOpc  = Imp0x0F | Imp0x0F38 | Imp0x0F3A  deriving (Eq,Show)
-data VexW       = VexW0 | VexW1                    deriving (Eq,Show)
-
--- | Note: this doesn't do any error checking.
-parseVex :: String -> VexSpec
-parseVex inp =
-  VexSpec { vexUseVVVV = vvvv
-          , vexSize    = size
-          , vexImpSimd = impS
-          , vexImpOpc  = impO
-          , vexW       = w
-          , vexAllowShort = short
-          }
-  where
-  ts0 = chunks inp
-
-  (vvvv,ts1) =
-    case ts0 of
-      f : fs | f == "NDS" -> (Just VEX_NDS, fs)
-             | f == "NDD" -> (Just VEX_NDD, fs)
-             | f == "DDS" -> (Just VEX_DDS, fs)
-      _ -> (Nothing, ts0)
-
-  (size,ts2) =
-    case ts1 of
-      f : fs | f == "128" -> (Vex128, fs)
-             | f == "256" -> (Vex256, fs)
-      _ -> error "VEX specification is missing its size field"
-
-  (impS,ts3) =
-    case ts2 of
-      f : fs | f == "66" -> (Just Imp0x66, fs)
-             | f == "F2" -> (Just Imp0xF2, fs)
-             | f == "F3" -> (Just Imp0xF3, fs)
-      _ -> (Nothing, ts2)
-
-  (impO,ts4) =
-     case ts3 of
-      f : fs | f == "0F"   -> (Just Imp0x0F,   fs)
-             | f == "0F3A" -> (Just Imp0x0F3A, fs)
-             | f == "0F38" -> (Just Imp0x0F38, fs)
-      _ -> (Nothing, ts3)
-
-  (w,ts5) =
-    case ts4 of
-      f : fs | f == "W0" -> (Just VexW0, fs)
-             | f == "W1" -> (Just VexW1, fs)
-      _ -> (Nothing, ts4)
-
-  short =
-    case ts5 of
-      f : _ | f == "WIG" -> True
-      _ -> False
-
-  chunks x = if null x then []
-                       else case break (== '.') x of
-                              (as,_:bs) -> as : chunks bs
-                              _         -> [x]
-
--- | Can this prefix use the short (2 byte) form?
-vexMayBeShort :: VexSpec -> Bool
-vexMayBeShort vp =
-  case vexImpOpc vp of
-    Just Imp0x0F38  -> False
-    Just Imp0x0F3A  -> False
-    _ -> case vexW vp of
-           Just VexW1 -> False
-           _          -> vexAllowShort vp
-
--- | Map a VEX prefix specificaiton for an instruction to the sequences
--- of bytes that will match it.
-vexToBytes :: VexSpec -> [[Word8]]
-vexToBytes vp = short ++ long
-  where
-  long  = [ [0xC4, b1, b2 ] | b1 <- longByte1, b2 <- longByte2 ]
-  short = if vexMayBeShort vp then [ [0xC5, b ] | b <- shortByte ] else []
-
-  shortByte = nubOrd
-              [ field 7 r .|. field 3 vvvv .|. field 2 l .|. pp
-              | r <- [ 0, 1 ], vvvv <- vvvvVals, l <- lVals, pp <- ppVals ]
-  longByte1 = nubOrd
-              [ field 5 rxb .|. m
-              | rxb <- [ 0 .. 7 ], m <- mmmmVals ]
-  longByte2 = nubOrd
-              [ field 7 w .|. field 3 vvvv .|. field 2 l .|. pp
-              | w <- wVals, vvvv <- vvvvVals, l <- lVals, pp <- ppVals ]
-
-  field amt x = shiftL x amt
-
-  vvvvVals = case vexUseVVVV vp of
-               Nothing -> [ 15 ]
-               Just _  -> [ 0 .. 15 ]
-
-  wVals    = case vexW vp of
-               Nothing    -> [ 0, 1 ]
-               Just VexW0 -> [ 0 ]
-               Just VexW1 -> [ 1 ]
-
-  lVals    = case vexSize vp of
-               Vex128 -> [0]
-               Vex256 -> [1]
-
-  ppVals   = case vexImpSimd vp of
-               Nothing      -> [ 0 ]
-               Just Imp0x66 -> [ 1 ]
-               Just Imp0xF3 -> [ 2 ]
-               Just Imp0xF2 -> [ 3 ]
-
-  mmmmVals = case vexImpOpc vp of
-               Nothing -> []
-               Just imp ->
-                 case imp of
-                   Imp0x0F   -> [1]
-                   Imp0x0F38 -> [2]
-                   Imp0x0F3A -> [3]
-
-
-
 ------------------------------------------------------------------------
--- Instruction
+-- OperandSizeConstraint / Def
 
 data OperandSizeConstraint
    = OpSize16
@@ -462,37 +141,39 @@ data OperandSizeConstraint
 instance DS.NFData OperandSizeConstraint
 
 -- | The definition of an instruction.
-data Def = Def  { _defMnemonic :: !BS.ByteString
-                  -- ^ Canonical mnemonic
-                , _defMnemonicSynonyms :: [BS.ByteString]
-                  -- ^ Additional mnemonics, not including
-                  -- the canonical mnemonic. Used e.g. by
-                  -- jump instructions.
-                , _defCPUReq :: CPURequirement
-                  -- ^ XXX: we should be able to combine these.
-                  -- For example, instruction `vaesenc` requires both
-                  -- AES and AVX support.
-                , _defVendor :: Maybe Vendor
-                , _modeLimit :: ModeLimit
-                , _defMode   :: Maybe Mode
-                , _reqAddrSize :: Maybe SizeConstraint
-                , _reqOpSize :: Maybe OperandSizeConstraint
-                , _defPrefix :: [String]
-                  -- ^ List of allowed prefixes.
-                , _requiredPrefix :: Maybe Word8
-                , _defOpcodes :: [Word8]
-                  -- ^ List of opcodes, which should be nonempty for
-                  -- a complete 'Def'.
-                , _requiredMod :: Maybe ModConstraint
-                , _requiredReg :: Maybe Fin8
-                , _requiredRM :: Maybe Fin8
-                , _x87ModRM    :: Maybe Fin64
-                , _vexPrefixes  :: ![ [Word8] ]
-                  -- ^ Allowed VEX prefixes for this instruction.
-                , _defOperands  :: ![OperandType]
-                } deriving (Eq, Generic, Lift, Show)
+--
+-- The constructor and record fields are exported so that
+-- "Flexdis86.OpTable.Parse" can construct values at compile time;
+-- callers outside this package should use the lens accessors below.
+data Def = Def
+  { _defMnemonic         :: !BS.ByteString
+    -- ^ Canonical mnemonic
+  , _defMnemonicSynonyms :: [BS.ByteString]
+    -- ^ Additional mnemonics (e.g., for jump instructions).
+  , _defCPUReq           :: CPURequirement
+  , _defVendor           :: Maybe Vendor
+  , _modeLimit           :: ModeLimit
+  , _defMode             :: Maybe Mode
+  , _reqAddrSize         :: Maybe SizeConstraint
+  , _reqOpSize           :: Maybe OperandSizeConstraint
+  , _defPrefix           :: [String]
+    -- ^ List of allowed prefixes.
+  , _requiredPrefix      :: Maybe Word8
+  , _defOpcodes          :: [Word8]
+    -- ^ List of opcodes (nonempty for a complete 'Def').
+  , _requiredMod         :: Maybe ModConstraint
+  , _requiredReg         :: Maybe Fin8
+  , _requiredRM          :: Maybe Fin8
+  , _x87ModRM            :: Maybe Fin64
+  , _vexPrefixes         :: ![[Word8]]
+    -- ^ Allowed VEX prefix byte sequences for this instruction.
+  , _defOperands         :: ![OperandType]
+  } deriving (Eq, Generic, Lift, Show)
 
 instance DS.NFData Def
+
+------------------------------------------------------------------------
+-- Def lenses
 
 -- | Canonical mnemonic for definition.
 defMnemonic :: Lens' Def BS.ByteString
@@ -567,121 +248,30 @@ vexPrefixes = lens _vexPrefixes (\s v -> s { _vexPrefixes = v })
 defOperands :: Lens' Def [OperandType]
 defOperands = lens _defOperands (\s v -> s { _defOperands = v })
 
+------------------------------------------------------------------------
+-- Filtering
+
 -- | CPU requirements accepted by flexdis86.
 supportedCPUReqs :: [CPURequirement]
-supportedCPUReqs = [Base, SSE, SSE2, SSE3, SSE3_atom, SSE4_1, SSE4_2, X87, AESNI, SHA, AVX, BMI2, ADX]
+supportedCPUReqs =
+  [Base, SSE, SSE2, SSE3, SSE3_atom, SSE4_1, SSE4_2,
+   X87, AESNI, SHA, AVX, BMI2, ADX]
 
--- | Return true if this definition is one supported by flexdis86.
-defSupported :: Def -> Bool
-defSupported d = d^.reqAddrSize /= Just Size16
-                 && d^.defCPUReq `elem` supportedCPUReqs
-                 && x64Compatible d
-
-addOpcode :: MonadState Def m => Word8 -> m ()
-addOpcode c = defOpcodes %= (++ [c])
-
-setDefCPUReq :: MonadState Def m => CPURequirement -> m ()
-setDefCPUReq r = do
-  creq <- use defCPUReq
-  when (creq == Base) $ defCPUReq .= r
-
--- | Parse opcode value
-parse_opcode :: (MonadState Def m, MF.MonadFail m) => String -> m ()
-parse_opcode nm = do
-  case readHex nm of
-    [(v,"")] -> addOpcode v
-    _ | Just r <- List.stripPrefix "/a=" nm
-      -> case r of
-           "16" -> reqAddrSize ?= Size16
-           "32" -> reqAddrSize ?= Size32
-           "64" -> reqAddrSize ?= Size64
-           _ -> fail $ "Unexpected address size: " ++ r
-    _ | Just r <- List.stripPrefix "/m=" nm
-      -> case r of
-           "32"  -> modeLimit .= Only32
-           "64"  -> modeLimit .= Only64
-           "!64" -> modeLimit .= Not64
-           _ -> fail $ "Unexpected mode limit: " ++ r
-    _ | Just r <- List.stripPrefix "/mod=" nm
-      -> case r of
-           "11"  -> requiredMod ?= OnlyReg
-           "!11" -> requiredMod ?= OnlyMem
-           _ -> fail $ "Unexpected mod constraint: " ++ r
-    _ | Just r <- List.stripPrefix "/o=" nm
-      , [(b,"")] <- readDec r
-      , b `elem` [16, 32, 64::Int]
-      -> case r of
-           "16" -> reqOpSize ?= OpSize16
-           "32" -> reqOpSize ?= OpSize32
-           "64" -> reqOpSize ?= OpSize64
-           _ -> fail $ "Unexpected operand size: " ++ r
-
-    _ | Just r <- List.stripPrefix "/reg=" nm
-      , [(b,"")] <- readHex r
-      , Just v <- asFin8 b
-      -> requiredReg ?= v
-    _ | Just r <- List.stripPrefix "/rm=" nm
-      , [(b,"")] <- readHex r
-      , Just v <- asFin8 b
-      -> requiredRM ?= v
-    _ | Just r <- List.stripPrefix "/3dnow=" nm
-      , [(b,"")] <- readHex r
-      -> do setDefCPUReq AMD_3DNOW
-            addOpcode b -- We don't use requiredPrefix here because it is a suffix
-    _ | Just r <- List.stripPrefix "/sse=" nm
-      , [(b,"")] <- readHex r
-      -> do setDefCPUReq SSE
-            requiredPrefix ?= b
-    _ | Just r <- List.stripPrefix "/x87=" nm
-      , [(b,"")] <- readHex r
-      , Just modRM <- asFin64 b
-      -> do setDefCPUReq X87
-            x87ModRM ?= modRM
-            -- FIXME: sjw: HACK to avoid making the parser more complex.  Basically, we
-            -- pretend we want both Reg and R/M
-            requiredRM  ?= maskFin8 b -- bottom 3 bits
-            requiredReg ?= maskFin8 (b `shiftR` 3)
-    -- This is a special hack used for the endbr32 and endbr64 instructions.
-    -- The first byte in their opcodes is parsed as a REP prefix, so we make
-    -- sure that it is present by marking it as a required prefix. See
-    -- Note [x86_64 disassembly] in Flexdis86.Disassembler for more details.
-    _ | Just r <- List.stripPrefix "/reqpfx=" nm
-      , [(b,"")] <- readHex r
-      -> requiredPrefix ?= b
-
-    _ | Just r <- List.stripPrefix "/vex=" nm
-      -> do setDefCPUReq AVX
-            vexPrefixes .= vexToBytes (parseVex r)
-
-    _  ->  fail $ "Unexpected opcode: " ++ show nm
-
-------------------------------------------------------------------------
--- Instruction
-
--- | Return instuction if instruction can be used with x64.
+-- | Return true if this instruction is compatible with 64-bit mode.
 x64Compatible :: Def -> Bool
 x64Compatible d =
   case d^.defOpcodes of
     [b] | null (d^.vexPrefixes) && (b .&. 0xF0 == 0x40) -> False
-    _ -> valid64 (d^.modeLimit)
+    _   -> valid64 (d^.modeLimit)
 
--- | Recognizes form for mnemonics
-isMnemonic :: String -> Bool
-isMnemonic (h:r) = ('a' <= h && h <= 'z' || h == '_') && all isLowerOrDigit r
-isMnemonic [] = False
+-- | Return true if this definition is one supported by flexdis86.
+defSupported :: Def -> Bool
+defSupported d = d^.reqAddrSize /= Just Size16
+              && d^.defCPUReq `elem` supportedCPUReqs
+              && x64Compatible d
 
-isLowerOrDigit :: Char -> Bool
-isLowerOrDigit c = 'a' <= c && c <= 'z' || isDigit c || c == '_'
-
-parse_mnemonics :: ElemParser (BS.ByteString, [BS.ByteString])
-parse_mnemonics = do
-  mnems <- words <$> required_text "mnemonic"
-  forM_ mnems $ \mnem -> do
-    unless (isMnemonic mnem) $
-      fail $ "Invalid mnemonic: " ++ show mnem
-  case BSC.pack <$> mnems of
-    [] -> fail "Empty mnemonic element!"
-    (h:t) -> return (h, t)
+------------------------------------------------------------------------
+-- Operand lookup
 
 operandHandlerMap :: Map.Map String OperandType
 operandHandlerMap = Map.fromList
@@ -763,8 +353,7 @@ operandHandlerMap = Map.fromList
     -- MMX register stored in ModRM.reg
   , (,) "P"    $ RG_MMX_reg
 
-    -- MMX register stored in ModRM.rm
-    -- (ModRM.mod must equal 3).
+    -- MMX register stored in ModRM.rm (ModRM.mod must equal 3).
   , (,) "N"    $ RG_MMX_rm
    -- Register operand stored in ModRM.rm (ModRM.mod must equal 3)
   , (,) "R"    $ OpType ModRM_rm_mod3 RDQSize
@@ -787,11 +376,9 @@ operandHandlerMap = Map.fromList
   , (,) "MwRd" $ MXRX WSize DSize
   , (,) "MwRy" $ MXRX WSize YSize
 
-    -- Far Pointer (which is an address) stored in ModRM.rm
-    -- (ModRM.mod must not equal 3)
+    -- Far Pointer stored in ModRM.rm (ModRM.mod must not equal 3)
   , (,) "Fv"   $ M_FP
-    -- Memory value stored in ModRM.rm
-    -- (ModRM.mod must not equal 3)
+    -- Memory value stored in ModRM.rm (ModRM.mod must not equal 3)
   , (,) "M"    $ M
   , (,) "Mo"   $ M_X OSize
     -- A reference to an 80-bit floating point value
@@ -801,8 +388,7 @@ operandHandlerMap = Map.fromList
   , (,) "M32fp" $ M_FloatingPoint FPSize32
   , (,) "M64fp" $ M_FloatingPoint FPSize64
 
-
-    -- FP Register indicies
+    -- FP Register indices
   , (,) "ST0"   $ RG_ST 0
   , (,) "ST1"   $ RG_ST 1
   , (,) "ST2"   $ RG_ST 2
@@ -849,8 +435,7 @@ operandHandlerMap = Map.fromList
 
     -- An immediate byte that is sign extended to an operator size.
   , (,) "sIb" $ IM_SB
-    -- An immediate ZSize value that is sign extended to the operator
-    -- size.
+    -- An immediate ZSize value that is sign extended to the operator size.
   , (,) "sIz" $ IM_SZ
 
     -- XMM
@@ -879,94 +464,5 @@ operandHandlerMap = Map.fromList
 lookupOperandType :: MF.MonadFail m => BS.ByteString -> String -> m OperandType
 lookupOperandType i nm =
   case Map.lookup nm operandHandlerMap of
-    Just h -> pure h
+    Just h  -> pure h
     Nothing -> fail $ "Unknown operand for " ++ BSC.unpack i ++ " named " ++ show nm
-
--- | Reverses a list while ensuring the spine of the list is strictly evaluated.
-strictReverse :: [a] -> [a]
-strictReverse = go []
-  where go :: [a] -> [a] -> [a]
-        go r [] = r
-        go r (a:l) = (go $! (a:r)) l
-
--- | Map over a list strictly.
-strictMapList :: Monad m => (a -> m b) -> [a] -> m [b]
-strictMapList = go []
-  where go :: Monad m => [b] -> (a -> m b) -> [a] -> m [b]
-        go r _ [] = pure $! strictReverse r
-        go r f (a:l) = do
-          b <- f a
-          seq b $ go (b:r) f l
-
--- | Parse a definition, returning 'Nothing' if the definition is not
--- supported by flexdis86 (detected as early as possible).
-parse_def ::
-  BS.ByteString ->
-  [BS.ByteString] ->
-  CPURequirement ->
-  Maybe Vendor ->
-  ElemParser (Maybe Def)
-parse_def nm syns creq v = do
-  checkTag "def"
-  let parse_prefix = fromMaybe [] . fmap words <$> opt "pfx" asText
-  prefix <- parse_prefix
-  opc_text <- required_text "opc"
-  oprndNames <- fromMaybe [] . fmap words <$> opt "opr" asText
-  mode <- parse_mode
-  creq' <- parse_CPURequirement creq
-  v' <- parse_vendor v
-  checkEnd
-  -- All XML consumed. Early exit if creq' is definitively unsupported.
-  -- Base is kept because parse_opcode may still override it (e.g. to AMD_3DNOW).
-  if creq' `notElem` (Base : supportedCPUReqs) then return Nothing else do
-    oprnds <- strictMapList (lookupOperandType nm) oprndNames
-    let d0 = Def { _defMnemonic = nm
-                 , _defMnemonicSynonyms = syns
-                 , _defCPUReq = creq'
-                 , _defVendor = v'
-                 , _modeLimit = AnyMode
-                 , _defMode = mode
-                 , _reqAddrSize = Nothing
-                 , _reqOpSize = Nothing
-                 , _defPrefix = prefix
-                 , _requiredPrefix = Nothing
-                 , _defOpcodes = []
-                 , _requiredMod = Nothing
-                 , _requiredReg = Nothing
-                 , _requiredRM  = Nothing
-                 , _x87ModRM = Nothing
-                 , _vexPrefixes = []
-                 , _defOperands = oprnds
-                 }
-    d <- seq d0 $ flip execStateT d0 $ do
-           mapM_ parse_opcode (words opc_text)
-    return $ if defSupported d then Just d else Nothing
-
--- | Consume and discard all remaining elements in the current context.
-skipRemainingElts :: ElemParser ()
-skipRemainingElts = do
-  me <- getNextElt
-  case me of
-    Nothing -> return ()
-    Just _  -> skipRemainingElts
-
-parse_instruction :: ElemParser [Def]
-parse_instruction = do
-  checkTag "instruction"
-  (mnem, syns) <- parse_mnemonics
-  cpuReq <- parse_CPURequirement Base
-  v <- parse_vendor Nothing
-  if cpuReq `notElem` (Base : supportedCPUReqs)
-    then skipRemainingElts >> return []
-    else catMaybes <$> remainingElts (parse_def mnem syns cpuReq v)
-
-parse_x86_optable :: ElemParser [Def]
-parse_x86_optable = do
-  checkTag "x86optable"
-  concat <$> remainingElts parse_instruction
-
-parseOpTable :: BS.ByteString -> Either String [Def]
-parseOpTable bs = do
-  case parseXMLDoc bs of
-    Nothing -> Left "Not an XML document"
-    Just elt -> runElemParser parse_x86_optable elt

--- a/src/Flexdis86/OpTable.hs
+++ b/src/Flexdis86/OpTable.hs
@@ -7,7 +7,6 @@ Types describing x86 instruction definitions, and utilities for working
 with them at runtime.  XML parsing lives in "Flexdis86.OpTable.Parse".
 -}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DeriveLift #-}
 module Flexdis86.OpTable
   ( -- * Primitive types
     Mode(..)
@@ -44,13 +43,12 @@ module Flexdis86.OpTable
 import qualified Control.DeepSeq as DS
 import qualified Control.Monad.Fail as MF
 import           Data.Bits ((.&.))
+import           Data.Binary (Binary)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BSC
 import qualified Data.Map.Strict as Map
 import           Data.Word (Word8)
 import           GHC.Generics (Generic)
-import           Instances.TH.Lift ()
-import           Language.Haskell.TH.Syntax (Lift)
 import           Lens.Micro (Lens', lens, (^.))
 
 import           Flexdis86.Operand
@@ -67,9 +65,11 @@ data Mode
    = Default64
      -- | Instruction is invalid in x64 mode.
    | Invalid64
-  deriving (Eq, Generic, Lift, Ord, Show)
+  deriving (Eq, Generic, Ord, Show)
 
 instance DS.NFData Mode
+-- | For "Flexdis86.OpTable.Parse".
+instance Binary Mode
 
 ------------------------------------------------------------------------
 -- CPURequirement
@@ -100,18 +100,22 @@ data CPURequirement
    | AVX    -- ^ Advanced vector extensions
    | BMI2   -- ^ Bit manipulation instructions
    | ADX    -- ^ Multi-precision add-carry instructions
-  deriving (Eq, Generic, Lift, Ord, Show)
+  deriving (Eq, Generic, Ord, Show)
 
 instance DS.NFData CPURequirement
+-- | For "Flexdis86.OpTable.Parse".
+instance Binary CPURequirement
 
 ------------------------------------------------------------------------
 -- Vendor
 
 -- | Defines whether instruction is vendor specific.
 data Vendor = AMD | Intel
-  deriving (Eq, Generic, Lift, Ord, Show)
+  deriving (Eq, Generic, Ord, Show)
 
 instance DS.NFData Vendor
+-- | For "Flexdis86.OpTable.Parse".
+instance Binary Vendor
 
 ------------------------------------------------------------------------
 -- ModeLimit
@@ -122,9 +126,11 @@ data ModeLimit
    | Only32
    | Only64
    | Not64
-  deriving (Eq, Generic, Lift, Show)
+  deriving (Eq, Generic, Show)
 
 instance DS.NFData ModeLimit
+-- | For "Flexdis86.OpTable.Parse".
+instance Binary ModeLimit
 
 valid64 :: ModeLimit -> Bool
 valid64 m = m == AnyMode || m == Only64
@@ -136,41 +142,46 @@ data OperandSizeConstraint
    = OpSize16
    | OpSize32
    | OpSize64
-  deriving (Eq, Generic, Lift, Show)
+  deriving (Eq, Generic, Show)
 
 instance DS.NFData OperandSizeConstraint
+-- | For "Flexdis86.OpTable.Parse".
+instance Binary OperandSizeConstraint
 
 -- | The definition of an instruction.
---
--- The constructor and record fields are exported so that
--- "Flexdis86.OpTable.Parse" can construct values at compile time;
--- callers outside this package should use the lens accessors below.
-data Def = Def
-  { _defMnemonic         :: !BS.ByteString
-    -- ^ Canonical mnemonic
-  , _defMnemonicSynonyms :: [BS.ByteString]
-    -- ^ Additional mnemonics (e.g., for jump instructions).
-  , _defCPUReq           :: CPURequirement
-  , _defVendor           :: Maybe Vendor
-  , _modeLimit           :: ModeLimit
-  , _defMode             :: Maybe Mode
-  , _reqAddrSize         :: Maybe SizeConstraint
-  , _reqOpSize           :: Maybe OperandSizeConstraint
-  , _defPrefix           :: [String]
-    -- ^ List of allowed prefixes.
-  , _requiredPrefix      :: Maybe Word8
-  , _defOpcodes          :: [Word8]
-    -- ^ List of opcodes (nonempty for a complete 'Def').
-  , _requiredMod         :: Maybe ModConstraint
-  , _requiredReg         :: Maybe Fin8
-  , _requiredRM          :: Maybe Fin8
-  , _x87ModRM            :: Maybe Fin64
-  , _vexPrefixes         :: ![[Word8]]
-    -- ^ Allowed VEX prefix byte sequences for this instruction.
-  , _defOperands         :: ![OperandType]
-  } deriving (Eq, Generic, Lift, Show)
+data Def = Def  { _defMnemonic         :: !BS.ByteString
+                  -- ^ Canonical mnemonic
+                , _defMnemonicSynonyms :: [BS.ByteString]
+                  -- ^ Additional mnemonics, not including
+                  -- the canonical mnemonic. Used e.g. by
+                  -- jump instructions.
+                , _defCPUReq :: CPURequirement
+                  -- ^ XXX: we should be able to combine these.
+                  -- For example, instruction `vaesenc` requires both
+                  -- AES and AVX support.
+                , _defVendor :: Maybe Vendor
+                , _modeLimit :: ModeLimit
+                , _defMode   :: Maybe Mode
+                , _reqAddrSize :: Maybe SizeConstraint
+                , _reqOpSize :: Maybe OperandSizeConstraint
+                , _defPrefix :: [String]
+                  -- ^ List of allowed prefixes.
+                , _requiredPrefix :: Maybe Word8
+                , _defOpcodes :: [Word8]
+                  -- ^ List of opcodes, which should be nonempty for
+                  -- a complete 'Def'.
+                , _requiredMod :: Maybe ModConstraint
+                , _requiredReg :: Maybe Fin8
+                , _requiredRM :: Maybe Fin8
+                , _x87ModRM    :: Maybe Fin64
+                , _vexPrefixes  :: ![ [Word8] ]
+                  -- ^ Allowed VEX prefixes for this instruction.
+                , _defOperands  :: ![OperandType]
+                } deriving (Eq, Generic, Show)
 
 instance DS.NFData Def
+-- | For "Flexdis86.OpTable.Parse".
+instance Binary Def
 
 ------------------------------------------------------------------------
 -- Def lenses

--- a/src/Flexdis86/OpTable.hs
+++ b/src/Flexdis86/OpTable.hs
@@ -8,6 +8,7 @@ instruction set.
 -}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -59,6 +60,8 @@ import qualified Data.Map.Strict as Map
 import           Data.Maybe
 import           Data.Word
 import           GHC.Generics
+import           Instances.TH.Lift ()
+import           Language.Haskell.TH.Syntax (Lift)
 import           Lens.Micro (Lens', lens, (^.))
 import           Lens.Micro.Mtl ((%=), (.=), (?=), use)
 import           Numeric (readDec, readHex)
@@ -202,7 +205,7 @@ data Mode
    = Default64
      -- | Instruction is invalid in x64 mode.
    | Invalid64
-  deriving (Eq, Generic, Ord,Show)
+  deriving (Eq, Generic, Lift, Ord, Show)
 
 instance DS.NFData Mode
 
@@ -247,7 +250,7 @@ data CPURequirement
 
    -- | Multi-precision add-carry instructions
    | ADX
-  deriving (Eq, Generic, Ord, Show)
+  deriving (Eq, Generic, Lift, Ord, Show)
 
 instance DS.NFData CPURequirement
 
@@ -284,7 +287,7 @@ parse_CPURequirement c = do
 
 -- | Defines whether instuction is vendor specific.
 data Vendor = AMD | Intel
-  deriving (Eq, Generic, Ord, Show)
+  deriving (Eq, Generic, Lift, Ord, Show)
 
 instance DS.NFData Vendor
 
@@ -305,7 +308,7 @@ data ModeLimit
    | Only32
    | Only64
    | Not64
-  deriving (Eq, Generic, Show)
+  deriving (Eq, Generic, Lift, Show)
 
 instance DS.NFData ModeLimit
 
@@ -454,7 +457,7 @@ data OperandSizeConstraint
    = OpSize16
    | OpSize32
    | OpSize64
-  deriving (Eq, Generic, Show)
+  deriving (Eq, Generic, Lift, Show)
 
 instance DS.NFData OperandSizeConstraint
 
@@ -487,7 +490,7 @@ data Def = Def  { _defMnemonic :: !BS.ByteString
                 , _vexPrefixes  :: ![ [Word8] ]
                   -- ^ Allowed VEX prefixes for this instruction.
                 , _defOperands  :: ![OperandType]
-                } deriving (Eq, Generic, Show)
+                } deriving (Eq, Generic, Lift, Show)
 
 instance DS.NFData Def
 
@@ -564,10 +567,14 @@ vexPrefixes = lens _vexPrefixes (\s v -> s { _vexPrefixes = v })
 defOperands :: Lens' Def [OperandType]
 defOperands = lens _defOperands (\s v -> s { _defOperands = v })
 
+-- | CPU requirements accepted by flexdis86.
+supportedCPUReqs :: [CPURequirement]
+supportedCPUReqs = [Base, SSE, SSE2, SSE3, SSE3_atom, SSE4_1, SSE4_2, X87, AESNI, SHA, AVX, BMI2, ADX]
+
 -- | Return true if this definition is one supported by flexdis86.
 defSupported :: Def -> Bool
 defSupported d = d^.reqAddrSize /= Just Size16
-                 && (d^.defCPUReq `elem` [Base, SSE, SSE2, SSE3, SSE3_atom, SSE4_1, SSE4_2, X87, AESNI, SHA, AVX, BMI2, ADX])
+                 && d^.defCPUReq `elem` supportedCPUReqs
                  && x64Compatible d
 
 addOpcode :: MonadState Def m => Word8 -> m ()
@@ -891,13 +898,14 @@ strictMapList = go []
           b <- f a
           seq b $ go (b:r) f l
 
--- | Parse a definition.
+-- | Parse a definition, returning 'Nothing' if the definition is not
+-- supported by flexdis86 (detected as early as possible).
 parse_def ::
   BS.ByteString ->
   [BS.ByteString] ->
   CPURequirement ->
   Maybe Vendor ->
-  ElemParser Def
+  ElemParser (Maybe Def)
 parse_def nm syns creq v = do
   checkTag "def"
   let parse_prefix = fromMaybe [] . fmap words <$> opt "pfx" asText
@@ -908,28 +916,39 @@ parse_def nm syns creq v = do
   creq' <- parse_CPURequirement creq
   v' <- parse_vendor v
   checkEnd
-  oprnds <- strictMapList (lookupOperandType nm) oprndNames
+  -- All XML consumed. Early exit if creq' is definitively unsupported.
+  -- Base is kept because parse_opcode may still override it (e.g. to AMD_3DNOW).
+  if creq' `notElem` (Base : supportedCPUReqs) then return Nothing else do
+    oprnds <- strictMapList (lookupOperandType nm) oprndNames
+    let d0 = Def { _defMnemonic = nm
+                 , _defMnemonicSynonyms = syns
+                 , _defCPUReq = creq'
+                 , _defVendor = v'
+                 , _modeLimit = AnyMode
+                 , _defMode = mode
+                 , _reqAddrSize = Nothing
+                 , _reqOpSize = Nothing
+                 , _defPrefix = prefix
+                 , _requiredPrefix = Nothing
+                 , _defOpcodes = []
+                 , _requiredMod = Nothing
+                 , _requiredReg = Nothing
+                 , _requiredRM  = Nothing
+                 , _x87ModRM = Nothing
+                 , _vexPrefixes = []
+                 , _defOperands = oprnds
+                 }
+    d <- seq d0 $ flip execStateT d0 $ do
+           mapM_ parse_opcode (words opc_text)
+    return $ if defSupported d then Just d else Nothing
 
-  let d0 = Def { _defMnemonic = nm
-               , _defMnemonicSynonyms = syns
-               , _defCPUReq = creq'
-               , _defVendor = v'
-               , _modeLimit = AnyMode
-               , _defMode = mode
-               , _reqAddrSize = Nothing
-               , _reqOpSize = Nothing
-               , _defPrefix = prefix
-               , _requiredPrefix = Nothing
-               , _defOpcodes = []
-               , _requiredMod = Nothing
-               , _requiredReg = Nothing
-               , _requiredRM  = Nothing
-               , _x87ModRM = Nothing
-               , _vexPrefixes = []
-               , _defOperands = oprnds
-               }
-  seq d0 $ flip execStateT d0 $ do
-    mapM_ parse_opcode (words opc_text)
+-- | Consume and discard all remaining elements in the current context.
+skipRemainingElts :: ElemParser ()
+skipRemainingElts = do
+  me <- getNextElt
+  case me of
+    Nothing -> return ()
+    Just _  -> skipRemainingElts
 
 parse_instruction :: ElemParser [Def]
 parse_instruction = do
@@ -937,7 +956,9 @@ parse_instruction = do
   (mnem, syns) <- parse_mnemonics
   cpuReq <- parse_CPURequirement Base
   v <- parse_vendor Nothing
-  remainingElts (parse_def mnem syns cpuReq v)
+  if cpuReq `notElem` (Base : supportedCPUReqs)
+    then skipRemainingElts >> return []
+    else catMaybes <$> remainingElts (parse_def mnem syns cpuReq v)
 
 parse_x86_optable :: ElemParser [Def]
 parse_x86_optable = do

--- a/src/Flexdis86/OpTable/Parse.hs
+++ b/src/Flexdis86/OpTable/Parse.hs
@@ -1,0 +1,535 @@
+{- |
+Module      : Flexdis86.OpTable.Parse
+Copyright   : (c) Galois, Inc 2026
+Description : Parse @optable.xml@ into a list of 'Def's
+Maintainer  : langston@galois.com
+
+This module is used only at compile time (via a Template Haskell splice in
+"Flexdis86.DefaultParser"); it is not needed at runtime.
+-}
+
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PatternGuards #-}
+
+module Flexdis86.OpTable.Parse
+  ( parseOpTable
+  ) where
+
+import qualified Control.Monad.Fail as MF
+import           Control.Monad (forM_, unless, when)
+import           Control.Monad.State ( MonadState(..)
+                                     , execStateT
+                                     , gets
+                                     )
+import           Data.Bits ((.|.), shiftL, shiftR)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BSC
+import           Data.Char (isDigit, isSpace)
+import           Data.Containers.ListUtils (nubOrd)
+import qualified Data.List as List
+import qualified Data.Map.Strict as Map
+import           Data.Maybe (catMaybes, fromMaybe)
+import           Data.Word (Word8)
+import           Numeric (readDec, readHex)
+import           Text.XML.Light ( Content(..)
+                                , Element(..)
+                                , Line
+                                , QName(..)
+                                , cdData
+                                , cdVerbatim
+                                , elContent
+                                , elLine
+                                , elName
+                                , parseXMLDoc
+                                , CDataKind(..)
+                                )
+
+import           Lens.Micro.Mtl ((%=), (.=), (?=), use)
+
+import           Flexdis86.OpTable
+import           Flexdis86.Sizes (SizeConstraint(..), ModConstraint(..), asFin8, asFin64, maskFin8)
+
+------------------------------------------------------------------------
+-- ElemParser
+
+qname :: String -> QName
+qname nm = QName { qName = nm, qURI = Nothing, qPrefix = Nothing }
+
+ppQName :: QName -> String
+ppQName qnm = qName qnm
+
+data ElemState = ElemState { esName    :: QName
+                           , esContent :: [Content]
+                           , esLine    :: Maybe Line
+                           }
+
+mkElemState :: Element -> ElemState
+mkElemState e = ElemState { esName    = elName e
+                          , esContent = elContent e
+                          , esLine    = elLine e
+                          }
+
+newtype ElemParser a = EP { unEP :: ElemState -> Either String (a, ElemState) }
+
+instance Functor ElemParser where
+  fmap f m = EP (\s -> case unEP m s of
+                         Left e       -> Left e
+                         Right (v,s') -> Right (f v, s'))
+
+instance Applicative ElemParser where
+  pure v    = EP $ \s -> Right (v, s)
+  m <*> h   = EP $ \s -> do
+    (f, s1) <- unEP m s
+    (x, s2) <- unEP h s1
+    return (f x, s2)
+
+instance Monad ElemParser where
+  return = pure
+  m >>= h = EP $ \s -> do
+    (v, s') <- unEP m s
+    unEP (h v) s'
+#if !(MIN_VERSION_base(4,13,0))
+  fail = MF.fail
+#endif
+
+instance MF.MonadFail ElemParser where
+  fail e = EP $ \s -> Left $ show (esLine s) ++ ": " ++ e
+
+instance MonadState ElemState ElemParser where
+  get   = EP (\s -> Right (s, s))
+  put v = EP (\_ -> Right ((), v))
+
+runWithElement :: ElemParser a -> Element -> ElemParser a
+runWithElement m e = do
+  s <- get
+  put (mkElemState e)
+  v <- m
+  put s
+  return v
+
+runElemParser :: ElemParser a -> Element -> Either String a
+runElemParser m e = fmap fst (unEP m (mkElemState e))
+
+checkTag :: String -> ElemParser ()
+checkTag nm = do
+  enm <- gets esName
+  when (enm /= qname nm) $
+    fail $ "Unexpected tag " ++ ppQName enm ++ " in element."
+
+getNextElt :: ElemParser (Maybe Element)
+getNextElt = do
+  s <- get
+  case esContent s of
+    [] -> return Nothing
+    (h:r) -> do
+      put s { esContent = r }
+      case h of
+        Elem e                                    -> return (Just e)
+        Text d | dropWhile isSpace (cdData d) == "" -> getNextElt
+        t                                         -> fail $ "Unexpected non-whitespace text: " ++ show t
+
+pushElt :: Element -> ElemParser ()
+pushElt e = do
+  s <- get
+  put s { esContent = Elem e : esContent s }
+
+next :: ElemParser a -> ElemParser a
+next p = do
+  me <- getNextElt
+  case me of
+    Just e  -> runWithElement p e
+    Nothing -> fail "Failed to find next element."
+
+opt :: String -> ElemParser a -> ElemParser (Maybe a)
+opt nm p = do
+  me <- getNextElt
+  case me of
+    Nothing -> return Nothing
+    Just e
+      | elName e == qname nm -> fmap Just $ runWithElement p e
+      | otherwise            -> pushElt e >> return Nothing
+
+checkEnd :: ElemParser ()
+checkEnd = do
+  me <- getNextElt
+  case me of
+    Nothing -> return ()
+    Just e  -> pushElt e >> fail "Expected end of elements."
+
+remainingElts :: ElemParser a -> ElemParser [a]
+remainingElts p = go []
+  where go r = do
+          me <- getNextElt
+          case me of
+            Nothing -> return (reverse r)
+            Just e  -> do v <- runWithElement p e
+                          go (v:r)
+
+asText :: ElemParser String
+asText = do
+  s <- get
+  case esContent s of
+    [Text d] | cdVerbatim d == CDataText -> return (cdData d)
+    x -> fail (unlines [ "asText found non-text.", show x])
+
+required_text :: String -> ElemParser String
+required_text nm = next $ checkTag nm >> asText
+
+------------------------------------------------------------------------
+-- Mode / CPURequirement / Vendor parsers
+
+parse_mode :: ElemParser (Maybe Mode)
+parse_mode = opt "mode" $ do
+  txt <- asText
+  case txt of
+    "def64" -> return Default64
+    "inv64" -> return Invalid64
+    _       -> fail $ "Invalid mode: " ++ show txt
+
+insClassMap :: Map.Map String CPURequirement
+insClassMap = Map.fromList
+  [ (,) "X87"        X87
+  , (,) "X87 UNDOC"  X87_undocumented
+  , (,) "smx"        SMX
+  , (,) "sse"        SSE
+  , (,) "sse2"       SSE2
+  , (,) "sse3"       SSE3
+  , (,) "sse3 atom"  SSE3_atom
+  , (,) "sse4.1"     SSE4_1
+  , (,) "sse4.2"     SSE4_2
+  , (,) "aesni"      AESNI
+  , (,) "sha"        SHA
+  , (,) "avx"        AVX
+  , (,) "bmi2"       BMI2
+  , (,) "adx"        ADX
+  ]
+
+parse_CPURequirement :: CPURequirement -> ElemParser CPURequirement
+parse_CPURequirement c = do
+  fmap (fromMaybe c) $ opt "class" $ do
+    txt <- asText
+    case Map.lookup txt insClassMap of
+      Nothing -> fail $ "Unknown instruction class: " ++ show txt
+      Just v  -> do
+        when (c /= Base) $
+          fail $ "Instruction class already defined " ++ show (c, v)
+        return v
+
+parse_vendor :: Maybe Vendor -> ElemParser (Maybe Vendor)
+parse_vendor v = do
+  fmap (maybe v Just) $ opt "vendor" $ do
+    when (maybe False (const True) v) $
+      fail "Vendor already defined."
+    txt <- asText
+    case txt of
+      "amd"   -> return AMD
+      "intel" -> return Intel
+      _       -> fail $ "Unknown vendor: " ++ show txt
+
+------------------------------------------------------------------------
+-- VEX prefix helpers (used only during parsing)
+
+data VexSpec = VexSpec
+  { vexUseVVVV    :: Maybe VexUseVVVV
+  , vexSize       :: VexSize
+  , vexImpSimd    :: Maybe VexImpSimd
+  , vexImpOpc     :: Maybe VexImpOpc
+  , vexW          :: Maybe VexW
+  , vexAllowShort :: Bool
+  } deriving (Eq, Show)
+
+data VexUseVVVV = VEX_NDS | VEX_NDD | VEX_DDS      deriving (Eq, Show)
+data VexSize    = Vex128 | Vex256                   deriving (Eq, Show)
+data VexImpSimd = Imp0x66 | Imp0xF3 | Imp0xF2       deriving (Eq, Show)
+data VexImpOpc  = Imp0x0F | Imp0x0F38 | Imp0x0F3A   deriving (Eq, Show)
+data VexW       = VexW0 | VexW1                     deriving (Eq, Show)
+
+parseVex :: String -> VexSpec
+parseVex inp =
+  VexSpec { vexUseVVVV    = vvvv
+          , vexSize       = size
+          , vexImpSimd    = impS
+          , vexImpOpc     = impO
+          , vexW          = w
+          , vexAllowShort = short
+          }
+  where
+  ts0 = chunks inp
+
+  (vvvv, ts1) =
+    case ts0 of
+      f : fs | f == "NDS" -> (Just VEX_NDS, fs)
+             | f == "NDD" -> (Just VEX_NDD, fs)
+             | f == "DDS" -> (Just VEX_DDS, fs)
+      _                   -> (Nothing, ts0)
+
+  (size, ts2) =
+    case ts1 of
+      f : fs | f == "128" -> (Vex128, fs)
+             | f == "256" -> (Vex256, fs)
+      _ -> error "VEX specification is missing its size field"
+
+  (impS, ts3) =
+    case ts2 of
+      f : fs | f == "66" -> (Just Imp0x66, fs)
+             | f == "F2" -> (Just Imp0xF2, fs)
+             | f == "F3" -> (Just Imp0xF3, fs)
+      _                  -> (Nothing, ts2)
+
+  (impO, ts4) =
+    case ts3 of
+      f : fs | f == "0F"   -> (Just Imp0x0F,   fs)
+             | f == "0F3A" -> (Just Imp0x0F3A, fs)
+             | f == "0F38" -> (Just Imp0x0F38, fs)
+      _                    -> (Nothing, ts3)
+
+  (w, ts5) =
+    case ts4 of
+      f : fs | f == "W0" -> (Just VexW0, fs)
+             | f == "W1" -> (Just VexW1, fs)
+      _                  -> (Nothing, ts4)
+
+  short =
+    case ts5 of
+      f : _ | f == "WIG" -> True
+      _                  -> False
+
+  chunks x = if null x then []
+                       else case break (== '.') x of
+                              (as, _:bs) -> as : chunks bs
+                              _          -> [x]
+
+vexMayBeShort :: VexSpec -> Bool
+vexMayBeShort vp =
+  case vexImpOpc vp of
+    Just Imp0x0F38  -> False
+    Just Imp0x0F3A  -> False
+    _ -> case vexW vp of
+           Just VexW1 -> False
+           _          -> vexAllowShort vp
+
+vexToBytes :: VexSpec -> [[Word8]]
+vexToBytes vp = short ++ long
+  where
+  long  = [ [0xC4, b1, b2] | b1 <- longByte1, b2 <- longByte2 ]
+  short = if vexMayBeShort vp then [ [0xC5, b] | b <- shortByte ] else []
+
+  shortByte = nubOrd
+              [ field 7 r .|. field 3 vvvv .|. field 2 l .|. pp
+              | r <- [0, 1], vvvv <- vvvvVals, l <- lVals, pp <- ppVals ]
+  longByte1 = nubOrd
+              [ field 5 rxb .|. m
+              | rxb <- [0 .. 7], m <- mmmmVals ]
+  longByte2 = nubOrd
+              [ field 7 ww .|. field 3 vvvv .|. field 2 l .|. pp
+              | ww <- wVals, vvvv <- vvvvVals, l <- lVals, pp <- ppVals ]
+
+  field amt x = shiftL x amt
+
+  vvvvVals = case vexUseVVVV vp of
+               Nothing -> [15]
+               Just _  -> [0 .. 15]
+
+  wVals    = case vexW vp of
+               Nothing    -> [0, 1]
+               Just VexW0 -> [0]
+               Just VexW1 -> [1]
+
+  lVals    = case vexSize vp of
+               Vex128 -> [0]
+               Vex256 -> [1]
+
+  ppVals   = case vexImpSimd vp of
+               Nothing      -> [0]
+               Just Imp0x66 -> [1]
+               Just Imp0xF3 -> [2]
+               Just Imp0xF2 -> [3]
+
+  mmmmVals = case vexImpOpc vp of
+               Nothing  -> []
+               Just imp ->
+                 case imp of
+                   Imp0x0F   -> [1]
+                   Imp0x0F38 -> [2]
+                   Imp0x0F3A -> [3]
+
+------------------------------------------------------------------------
+-- Opcode / mnemonic parsers
+
+addOpcode :: MonadState Def m => Word8 -> m ()
+addOpcode c = defOpcodes %= (++ [c])
+
+setDefCPUReq :: MonadState Def m => CPURequirement -> m ()
+setDefCPUReq r = do
+  creq <- use defCPUReq
+  when (creq == Base) $ defCPUReq .= r
+
+parse_opcode :: (MonadState Def m, MF.MonadFail m) => String -> m ()
+parse_opcode nm = do
+  case readHex nm of
+    [(v, "")] -> addOpcode v
+    _ | Just r <- List.stripPrefix "/a=" nm
+      -> case r of
+           "16" -> reqAddrSize ?= Size16
+           "32" -> reqAddrSize ?= Size32
+           "64" -> reqAddrSize ?= Size64
+           _    -> fail $ "Unexpected address size: " ++ r
+    _ | Just r <- List.stripPrefix "/m=" nm
+      -> case r of
+           "32"  -> modeLimit .= Only32
+           "64"  -> modeLimit .= Only64
+           "!64" -> modeLimit .= Not64
+           _     -> fail $ "Unexpected mode limit: " ++ r
+    _ | Just r <- List.stripPrefix "/mod=" nm
+      -> case r of
+           "11"  -> requiredMod ?= OnlyReg
+           "!11" -> requiredMod ?= OnlyMem
+           _     -> fail $ "Unexpected mod constraint: " ++ r
+    _ | Just r <- List.stripPrefix "/o=" nm
+      , [(b, "")] <- readDec r
+      , b `elem` [16, 32, 64 :: Int]
+      -> case r of
+           "16" -> reqOpSize ?= OpSize16
+           "32" -> reqOpSize ?= OpSize32
+           "64" -> reqOpSize ?= OpSize64
+           _    -> fail $ "Unexpected operand size: " ++ r
+    _ | Just r <- List.stripPrefix "/reg=" nm
+      , [(b, "")] <- readHex r
+      , Just v    <- asFin8 b
+      -> requiredReg ?= v
+    _ | Just r <- List.stripPrefix "/rm=" nm
+      , [(b, "")] <- readHex r
+      , Just v    <- asFin8 b
+      -> requiredRM ?= v
+    _ | Just r <- List.stripPrefix "/3dnow=" nm
+      , [(b, "")] <- readHex r
+      -> do setDefCPUReq AMD_3DNOW
+            addOpcode b
+    _ | Just r <- List.stripPrefix "/sse=" nm
+      , [(b, "")] <- readHex r
+      -> do setDefCPUReq SSE
+            requiredPrefix ?= b
+    _ | Just r <- List.stripPrefix "/x87=" nm
+      , [(b, "")] <- readHex r
+      , Just modRM <- asFin64 b
+      -> do setDefCPUReq X87
+            x87ModRM ?= modRM
+            -- FIXME: sjw: HACK to avoid making the parser more complex.  Basically, we
+            -- pretend we want both Reg and R/M
+            requiredRM  ?= maskFin8 b -- bottom 3 bits
+            requiredReg ?= maskFin8 (b `shiftR` 3)
+    -- This is a special hack used for the endbr32 and endbr64 instructions.
+    -- The first byte in their opcodes is parsed as a REP prefix, so we make
+    -- sure that it is present by marking it as a required prefix. See
+    -- Note [x86_64 disassembly] in Flexdis86.Disassembler for more details.
+    _ | Just r <- List.stripPrefix "/reqpfx=" nm
+      , [(b, "")] <- readHex r
+      -> requiredPrefix ?= b
+    _ | Just r <- List.stripPrefix "/vex=" nm
+      -> do setDefCPUReq AVX
+            vexPrefixes .= vexToBytes (parseVex r)
+    _ -> fail $ "Unexpected opcode: " ++ show nm
+
+isMnemonic :: String -> Bool
+isMnemonic (h:r) = ('a' <= h && h <= 'z' || h == '_') && all isLowerOrDigit r
+isMnemonic []    = False
+
+isLowerOrDigit :: Char -> Bool
+isLowerOrDigit c = 'a' <= c && c <= 'z' || isDigit c || c == '_'
+
+parse_mnemonics :: ElemParser (BS.ByteString, [BS.ByteString])
+parse_mnemonics = do
+  mnems <- words <$> required_text "mnemonic"
+  forM_ mnems $ \mnem -> do
+    unless (isMnemonic mnem) $
+      fail $ "Invalid mnemonic: " ++ show mnem
+  case BSC.pack <$> mnems of
+    []    -> fail "Empty mnemonic element!"
+    (h:t) -> return (h, t)
+
+------------------------------------------------------------------------
+-- Def parser
+
+strictReverse :: [a] -> [a]
+strictReverse = go []
+  where go :: [a] -> [a] -> [a]
+        go r []    = r
+        go r (a:l) = (go $! (a:r)) l
+
+strictMapList :: Monad m => (a -> m b) -> [a] -> m [b]
+strictMapList = go []
+  where go :: Monad m => [b] -> (a -> m b) -> [a] -> m [b]
+        go r _ []    = pure $! strictReverse r
+        go r f (a:l) = do b <- f a
+                          seq b $ go (b:r) f l
+
+parse_def ::
+  BS.ByteString ->
+  [BS.ByteString] ->
+  CPURequirement ->
+  Maybe Vendor ->
+  ElemParser (Maybe Def)
+parse_def nm syns creq v = do
+  checkTag "def"
+  let parse_prefix = fromMaybe [] . fmap words <$> opt "pfx" asText
+  prefix     <- parse_prefix
+  opc_text   <- required_text "opc"
+  oprndNames <- fromMaybe [] . fmap words <$> opt "opr" asText
+  mode       <- parse_mode
+  creq'      <- parse_CPURequirement creq
+  v'         <- parse_vendor v
+  checkEnd
+  if creq' `notElem` (Base : supportedCPUReqs) then return Nothing else do
+    oprnds <- strictMapList (lookupOperandType nm) oprndNames
+    let d0 = Def { _defMnemonic        = nm
+                 , _defMnemonicSynonyms = syns
+                 , _defCPUReq          = creq'
+                 , _defVendor          = v'
+                 , _modeLimit          = AnyMode
+                 , _defMode            = mode
+                 , _reqAddrSize        = Nothing
+                 , _reqOpSize          = Nothing
+                 , _defPrefix          = prefix
+                 , _requiredPrefix     = Nothing
+                 , _defOpcodes         = []
+                 , _requiredMod        = Nothing
+                 , _requiredReg        = Nothing
+                 , _requiredRM         = Nothing
+                 , _x87ModRM           = Nothing
+                 , _vexPrefixes        = []
+                 , _defOperands        = oprnds
+                 }
+    d <- seq d0 $ flip execStateT d0 $ mapM_ parse_opcode (words opc_text)
+    return $ if defSupported d then Just d else Nothing
+
+skipRemainingElts :: ElemParser ()
+skipRemainingElts = do
+  me <- getNextElt
+  case me of
+    Nothing -> return ()
+    Just _  -> skipRemainingElts
+
+parse_instruction :: ElemParser [Def]
+parse_instruction = do
+  checkTag "instruction"
+  (mnem, syns) <- parse_mnemonics
+  cpuReq       <- parse_CPURequirement Base
+  v            <- parse_vendor Nothing
+  if cpuReq `notElem` (Base : supportedCPUReqs)
+    then skipRemainingElts >> return []
+    else catMaybes <$> remainingElts (parse_def mnem syns cpuReq v)
+
+parse_x86_optable :: ElemParser [Def]
+parse_x86_optable = do
+  checkTag "x86optable"
+  concat <$> remainingElts parse_instruction
+
+-- | Parse the optable.xml file, returning only the 'Def's supported by
+-- flexdis86 (i.e., those for which 'defSupported' returns 'True').
+parseOpTable :: BS.ByteString -> Either String [Def]
+parseOpTable bs =
+  case parseXMLDoc bs of
+    Nothing  -> Left "Not an XML document"
+    Just elt -> runElemParser parse_x86_optable elt

--- a/src/Flexdis86/OpTable/Parse.hs
+++ b/src/Flexdis86/OpTable/Parse.hs
@@ -74,8 +74,9 @@ mkElemState e = ElemState { esName    = elName e
                           , esLine    = elLine e
                           }
 
--- | Full parser state: current element context plus streaming Def accumulator.
--- The accumulator is never saved/restored by 'runWithElement'.
+-- | Full parser state: current element context plus streaming
+-- 'Binary'-serialized Def accumulator ('Put'). The accumulator is never
+-- saved/restored by 'runWithElement'.
 data ParseState = ParseState { psElem    :: !ElemState
                              , psBuilder :: !Put
                              }
@@ -544,9 +545,10 @@ parse_x86_optable = do
   checkTag "x86optable"
   remainingElts_ parse_instruction
 
--- | Parse the optable.xml file, returning only the 'Def's supported by
--- flexdis86 (i.e., those for which 'defSupported' returns 'True'),
--- serialized as a 'Data.Binary'-encoded @[Def]@ bytestring.
+-- | Parse the optable.xml file, returning only the 'Def's as a 'Data.Binary'-encoded bytestring.
+--
+-- Only returns 'Def's supported by flexdis86 (i.e., those for which
+-- 'defSupported' returns 'True').
 parseOpTable :: BS.ByteString -> Either String LBS.ByteString
 parseOpTable bs =
   case parseXMLDoc bs of

--- a/src/Flexdis86/OpTable/Parse.hs
+++ b/src/Flexdis86/OpTable/Parse.hs
@@ -24,13 +24,16 @@ import           Control.Monad.State ( MonadState(..)
                                      , gets
                                      )
 import           Data.Bits ((.|.), shiftL, shiftR)
+import qualified Data.Binary as Bin
+import           Data.Binary.Put (Put, runPut)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BSC
+import qualified Data.ByteString.Lazy as LBS
 import           Data.Char (isDigit, isSpace)
 import           Data.Containers.ListUtils (nubOrd)
 import qualified Data.List as List
 import qualified Data.Map.Strict as Map
-import           Data.Maybe (catMaybes, fromMaybe)
+import           Data.Maybe (fromMaybe)
 import           Data.Word (Word8)
 import           Numeric (readDec, readHex)
 import           Text.XML.Light ( Content(..)
@@ -71,7 +74,13 @@ mkElemState e = ElemState { esName    = elName e
                           , esLine    = elLine e
                           }
 
-newtype ElemParser a = EP { unEP :: ElemState -> Either String (a, ElemState) }
+-- | Full parser state: current element context plus streaming Def accumulator.
+-- The accumulator is never saved/restored by 'runWithElement'.
+data ParseState = ParseState { psElem    :: !ElemState
+                             , psBuilder :: !Put
+                             }
+
+newtype ElemParser a = EP { unEP :: ParseState -> Either String (a, ParseState) }
 
 instance Functor ElemParser where
   fmap f m = EP (\s -> case unEP m s of
@@ -95,22 +104,33 @@ instance Monad ElemParser where
 #endif
 
 instance MF.MonadFail ElemParser where
-  fail e = EP $ \s -> Left $ show (esLine s) ++ ": " ++ e
+  fail e = EP $ \s -> Left $ show (esLine (psElem s)) ++ ": " ++ e
 
 instance MonadState ElemState ElemParser where
-  get   = EP (\s -> Right (s, s))
-  put v = EP (\_ -> Right ((), v))
+  get   = EP (\s -> Right (psElem s, s))
+  put v = EP (\s -> Right ((), s { psElem = v }))
 
+-- | Run a sub-parser on a child element, restoring the element context
+-- afterwards while preserving any Defs emitted into the accumulator.
 runWithElement :: ElemParser a -> Element -> ElemParser a
-runWithElement m e = do
-  s <- get
-  put (mkElemState e)
-  v <- m
-  put s
-  return v
+runWithElement m e = EP $ \s ->
+  let s' = s { psElem = mkElemState e }
+  in case unEP m s' of
+       Left err       -> Left err
+       Right (v, s'') -> Right (v, s'' { psElem = psElem s })
 
-runElemParser :: ElemParser a -> Element -> Either String a
-runElemParser m e = fmap fst (unEP m (mkElemState e))
+runElemParser :: ElemParser () -> Element -> Either String Put
+runElemParser m e =
+  case unEP m (ParseState (mkElemState e) mempty) of
+    Left err     -> Left err
+    Right (_, s) -> Right (psBuilder s)
+
+-- | Emit a 'Def' into the streaming Binary accumulator.
+emitDef :: Def -> ElemParser ()
+emitDef d = EP $ \s -> Right
+  ( ()
+  , s { psBuilder = psBuilder s <> Bin.put d }
+  )
 
 checkTag :: String -> ElemParser ()
 checkTag nm = do
@@ -158,14 +178,12 @@ checkEnd = do
     Nothing -> return ()
     Just e  -> pushElt e >> fail "Expected end of elements."
 
-remainingElts :: ElemParser a -> ElemParser [a]
-remainingElts p = go []
-  where go r = do
-          me <- getNextElt
-          case me of
-            Nothing -> return (reverse r)
-            Just e  -> do v <- runWithElement p e
-                          go (v:r)
+remainingElts_ :: ElemParser () -> ElemParser ()
+remainingElts_ p = do
+  me <- getNextElt
+  case me of
+    Nothing -> return ()
+    Just e  -> runWithElement p e >> remainingElts_ p
 
 asText :: ElemParser String
 asText = do
@@ -470,7 +488,7 @@ parse_def ::
   [BS.ByteString] ->
   CPURequirement ->
   Maybe Vendor ->
-  ElemParser (Maybe Def)
+  ElemParser ()
 parse_def nm syns creq v = do
   checkTag "def"
   let parse_prefix = fromMaybe [] . fmap words <$> opt "pfx" asText
@@ -481,7 +499,7 @@ parse_def nm syns creq v = do
   creq'      <- parse_CPURequirement creq
   v'         <- parse_vendor v
   checkEnd
-  if creq' `notElem` (Base : supportedCPUReqs) then return Nothing else do
+  when (creq' `elem` (Base : supportedCPUReqs)) $ do
     oprnds <- strictMapList (lookupOperandType nm) oprndNames
     let d0 = Def { _defMnemonic        = nm
                  , _defMnemonicSynonyms = syns
@@ -502,7 +520,7 @@ parse_def nm syns creq v = do
                  , _defOperands        = oprnds
                  }
     d <- seq d0 $ flip execStateT d0 $ mapM_ parse_opcode (words opc_text)
-    return $ if defSupported d then Just d else Nothing
+    if defSupported d then emitDef d else return ()
 
 skipRemainingElts :: ElemParser ()
 skipRemainingElts = do
@@ -511,25 +529,28 @@ skipRemainingElts = do
     Nothing -> return ()
     Just _  -> skipRemainingElts
 
-parse_instruction :: ElemParser [Def]
+parse_instruction :: ElemParser ()
 parse_instruction = do
   checkTag "instruction"
   (mnem, syns) <- parse_mnemonics
   cpuReq       <- parse_CPURequirement Base
   v            <- parse_vendor Nothing
   if cpuReq `notElem` (Base : supportedCPUReqs)
-    then skipRemainingElts >> return []
-    else catMaybes <$> remainingElts (parse_def mnem syns cpuReq v)
+    then skipRemainingElts
+    else remainingElts_ (parse_def mnem syns cpuReq v)
 
-parse_x86_optable :: ElemParser [Def]
+parse_x86_optable :: ElemParser ()
 parse_x86_optable = do
   checkTag "x86optable"
-  concat <$> remainingElts parse_instruction
+  remainingElts_ parse_instruction
 
 -- | Parse the optable.xml file, returning only the 'Def's supported by
--- flexdis86 (i.e., those for which 'defSupported' returns 'True').
-parseOpTable :: BS.ByteString -> Either String [Def]
+-- flexdis86 (i.e., those for which 'defSupported' returns 'True'),
+-- serialized as a 'Data.Binary'-encoded @[Def]@ bytestring.
+parseOpTable :: BS.ByteString -> Either String LBS.ByteString
 parseOpTable bs =
   case parseXMLDoc bs of
     Nothing  -> Left "Not an XML document"
-    Just elt -> runElemParser parse_x86_optable elt
+    Just elt -> case runElemParser parse_x86_optable elt of
+      Left err     -> Left err
+      Right putAcc -> Right $ runPut putAcc

--- a/src/Flexdis86/Operand.hs
+++ b/src/Flexdis86/Operand.hs
@@ -6,6 +6,7 @@ Maintainer  : jhendrix@galois.com
 This defines constants used for low-level operand layout information.
 -}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE Safe #-}
 {-# LANGUAGE TupleSections #-}
 module Flexdis86.Operand
@@ -17,6 +18,7 @@ module Flexdis86.Operand
 import qualified Control.DeepSeq as DS
 import Data.Word ( Word8 )
 import GHC.Generics
+import Language.Haskell.TH.Syntax (Lift)
 
 import Flexdis86.Register
 import Flexdis86.Segment
@@ -50,7 +52,7 @@ data OperandSource
      -- ^ A jump location that is read in from instruction stream, and
      -- offset from current instruction pointer.
    | JumpImmediate
-  deriving (Eq, Generic, Ord, Show)
+  deriving (Eq, Generic, Lift, Ord, Show)
 
 instance DS.NFData OperandSource
 
@@ -67,7 +69,7 @@ data OperandSize
    | YSize -- ^ Operand size is 64-bits if operand size is 64 bits, and 32-bits otherwise.
    | ZSize -- ^ Operand size is 16-bits if operand size is 16 bits, and 32-bits otherwise.
    | RDQSize -- ^ Operand size is 64-bits on x64 and 32-bits on ia32.
-  deriving (Eq, Generic, Ord, Show)
+  deriving (Eq, Generic, Lift, Ord, Show)
 
 instance DS.NFData OperandSize
 
@@ -151,6 +153,6 @@ data OperandType
      -- and 16bits if operand size is 16bits.
      -- The value can be sign exected to match operator size.
    | IM_SZ
-  deriving (Eq, Generic, Ord, Show)
+  deriving (Eq, Generic, Lift, Ord, Show)
 
 instance DS.NFData OperandType

--- a/src/Flexdis86/Operand.hs
+++ b/src/Flexdis86/Operand.hs
@@ -6,7 +6,6 @@ Maintainer  : jhendrix@galois.com
 This defines constants used for low-level operand layout information.
 -}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE Safe #-}
 {-# LANGUAGE TupleSections #-}
 module Flexdis86.Operand
@@ -16,9 +15,9 @@ module Flexdis86.Operand
   ) where
 
 import qualified Control.DeepSeq as DS
-import Data.Word ( Word8 )
-import GHC.Generics
-import Language.Haskell.TH.Syntax (Lift)
+import           Data.Binary (Binary)
+import           Data.Word ( Word8 )
+import           GHC.Generics
 
 import Flexdis86.Register
 import Flexdis86.Segment
@@ -52,9 +51,11 @@ data OperandSource
      -- ^ A jump location that is read in from instruction stream, and
      -- offset from current instruction pointer.
    | JumpImmediate
-  deriving (Eq, Generic, Lift, Ord, Show)
+  deriving (Eq, Generic, Ord, Show)
 
 instance DS.NFData OperandSource
+-- | For "Flexdis86.OpTable.Parse".
+instance Binary OperandSource
 
 -- | The size of an operand in the udis86 file.
 data OperandSize
@@ -69,9 +70,11 @@ data OperandSize
    | YSize -- ^ Operand size is 64-bits if operand size is 64 bits, and 32-bits otherwise.
    | ZSize -- ^ Operand size is 16-bits if operand size is 16 bits, and 32-bits otherwise.
    | RDQSize -- ^ Operand size is 64-bits on x64 and 32-bits on ia32.
-  deriving (Eq, Generic, Lift, Ord, Show)
+  deriving (Eq, Generic, Ord, Show)
 
 instance DS.NFData OperandSize
+-- | For "Flexdis86.OpTable.Parse".
+instance Binary OperandSize
 
 data OperandType
      -- | Operand that comes from a source and size.
@@ -153,6 +156,8 @@ data OperandType
      -- and 16bits if operand size is 16bits.
      -- The value can be sign exected to match operator size.
    | IM_SZ
-  deriving (Eq, Generic, Lift, Ord, Show)
+  deriving (Eq, Generic, Ord, Show)
 
 instance DS.NFData OperandType
+-- | For "Flexdis86.OpTable.Parse".
+instance Binary OperandType

--- a/src/Flexdis86/Register.hs
+++ b/src/Flexdis86/Register.hs
@@ -8,6 +8,7 @@ Defines types for x86 registers.
 
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE Trustworthy #-}
 {-# LANGUAGE ViewPatterns #-}
@@ -87,6 +88,7 @@ import           Data.Bits
 import qualified Data.Vector as V
 import           Data.Word ( Word8 )
 import GHC.Generics
+import Language.Haskell.TH.Syntax (Lift)
 import qualified Prettyprinter as PP
 
 ------------------------------------------------------------------------
@@ -279,7 +281,7 @@ pattern EDI = Reg32 7
 
 -- | One of the 16 64-bit general purpose registers.
 newtype Reg64 = Reg64 { unReg64 :: Word8 }
-  deriving (Eq, Generic, Ord)
+  deriving (Eq, Generic, Lift, Ord)
 
 instance DS.NFData Reg64
 

--- a/src/Flexdis86/Register.hs
+++ b/src/Flexdis86/Register.hs
@@ -8,7 +8,6 @@ Defines types for x86 registers.
 
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE Trustworthy #-}
 {-# LANGUAGE ViewPatterns #-}
@@ -87,8 +86,8 @@ import           Control.Exception ( assert )
 import           Data.Bits
 import qualified Data.Vector as V
 import           Data.Word ( Word8 )
-import GHC.Generics
-import Language.Haskell.TH.Syntax (Lift)
+import           Data.Binary (Binary)
+import           GHC.Generics
 import qualified Prettyprinter as PP
 
 ------------------------------------------------------------------------
@@ -281,7 +280,10 @@ pattern EDI = Reg32 7
 
 -- | One of the 16 64-bit general purpose registers.
 newtype Reg64 = Reg64 { unReg64 :: Word8 }
-  deriving (Eq, Generic, Lift, Ord)
+  deriving (Eq, Generic, Ord)
+
+-- | For "Flexdis86.OpTable.Parse".
+instance Binary Reg64
 
 instance DS.NFData Reg64
 

--- a/src/Flexdis86/Segment.hs
+++ b/src/Flexdis86/Segment.hs
@@ -7,6 +7,7 @@ Defines a datatype for segments and supporting operations.
 -}
 
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE Safe #-}
 
@@ -27,6 +28,7 @@ module Flexdis86.Segment
 import qualified Control.DeepSeq as DS
 import Data.Word (Word8)
 import GHC.Generics
+import Language.Haskell.TH.Syntax (Lift)
 import qualified Prettyprinter as PP
 
 import Flexdis86.Register
@@ -36,7 +38,7 @@ import Flexdis86.Register
 
 -- | Refers to a memory segment.
 newtype Segment = Segment { _unSegment :: Word8 }
-  deriving (Eq, Generic, Ord)
+  deriving (Eq, Generic, Lift, Ord)
 
 instance DS.NFData Segment
 

--- a/src/Flexdis86/Segment.hs
+++ b/src/Flexdis86/Segment.hs
@@ -7,7 +7,6 @@ Defines a datatype for segments and supporting operations.
 -}
 
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE Safe #-}
 
@@ -26,9 +25,9 @@ module Flexdis86.Segment
   ) where
 
 import qualified Control.DeepSeq as DS
-import Data.Word (Word8)
-import GHC.Generics
-import Language.Haskell.TH.Syntax (Lift)
+import           Data.Binary (Binary)
+import           Data.Word (Word8)
+import           GHC.Generics
 import qualified Prettyprinter as PP
 
 import Flexdis86.Register
@@ -38,7 +37,10 @@ import Flexdis86.Register
 
 -- | Refers to a memory segment.
 newtype Segment = Segment { _unSegment :: Word8 }
-  deriving (Eq, Generic, Lift, Ord)
+  deriving (Eq, Generic, Ord)
+
+-- | For "Flexdis86.OpTable.Parse".
+instance Binary Segment
 
 instance DS.NFData Segment
 

--- a/src/Flexdis86/Sizes.hs
+++ b/src/Flexdis86/Sizes.hs
@@ -7,6 +7,7 @@ Maintainer  : jhendrix@galois.com
 Defines size types in the udis86 file.
 -}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE Trustworthy #-}
 module Flexdis86.Sizes (
@@ -26,16 +27,17 @@ import qualified Control.DeepSeq as DS
 import Data.Bits
 import Data.Word ( Word8 )
 import GHC.Generics
+import Language.Haskell.TH.Syntax (Lift)
 
 -- | Describes the size of a value.
 data SizeConstraint = Size16 | Size32 | Size64 | Size128 | Size256
-  deriving (Eq, Generic, Ord, Show)
+  deriving (Eq, Generic, Lift, Ord, Show)
 
 instance DS.NFData SizeConstraint
 
 -- | Describes whether a floating point memory address value is 32, 64, or 80-bits.
 data FPSizeConstraint = FPSize32 | FPSize64 | FPSize80
-  deriving (Eq, Generic, Ord, Show)
+  deriving (Eq, Generic, Lift, Ord, Show)
 
 instance DS.NFData FPSizeConstraint
 
@@ -43,13 +45,13 @@ instance DS.NFData FPSizeConstraint
 -- can be only memory (e.g. !11), only a register (e.g., =11).
 data ModConstraint = OnlyMem
                    | OnlyReg
-  deriving (Eq, Generic, Ord, Show)
+  deriving (Eq, Generic, Lift, Ord, Show)
 
 instance DS.NFData ModConstraint
 
 -- | A value 0-7.
 newtype Fin8 = Fin8 { unFin8 :: Word8 }
-  deriving (Eq, Generic, Ord, Show)
+  deriving (Eq, Generic, Lift, Ord, Show)
 
 instance DS.NFData Fin8
 
@@ -64,7 +66,7 @@ maskFin8 v = Fin8 (v .&. 0x7)
 
 -- | A value 0-63.
 newtype Fin64 = Fin64 { unFin64 :: Word8 }
-  deriving (Eq, Generic, Ord, Show)
+  deriving (Eq, Generic, Lift, Ord, Show)
 
 instance DS.NFData Fin64
 

--- a/src/Flexdis86/Sizes.hs
+++ b/src/Flexdis86/Sizes.hs
@@ -7,7 +7,6 @@ Maintainer  : jhendrix@galois.com
 Defines size types in the udis86 file.
 -}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE Trustworthy #-}
 module Flexdis86.Sizes (
@@ -24,36 +23,44 @@ module Flexdis86.Sizes (
   ) where
 
 import qualified Control.DeepSeq as DS
-import Data.Bits
-import Data.Word ( Word8 )
-import GHC.Generics
-import Language.Haskell.TH.Syntax (Lift)
+import           Data.Binary (Binary)
+import           Data.Bits
+import           Data.Word ( Word8 )
+import           GHC.Generics
 
 -- | Describes the size of a value.
 data SizeConstraint = Size16 | Size32 | Size64 | Size128 | Size256
-  deriving (Eq, Generic, Lift, Ord, Show)
+  deriving (Eq, Generic, Ord, Show)
 
 instance DS.NFData SizeConstraint
+-- | For "Flexdis86.OpTable.Parse".
+instance Binary SizeConstraint
 
 -- | Describes whether a floating point memory address value is 32, 64, or 80-bits.
 data FPSizeConstraint = FPSize32 | FPSize64 | FPSize80
-  deriving (Eq, Generic, Lift, Ord, Show)
+  deriving (Eq, Generic, Ord, Show)
 
 instance DS.NFData FPSizeConstraint
+-- | For "Flexdis86.OpTable.Parse".
+instance Binary FPSizeConstraint
 
 -- | Identifies whether the mod value of a RM field
 -- can be only memory (e.g. !11), only a register (e.g., =11).
 data ModConstraint = OnlyMem
                    | OnlyReg
-  deriving (Eq, Generic, Lift, Ord, Show)
+  deriving (Eq, Generic, Ord, Show)
 
 instance DS.NFData ModConstraint
+-- | For "Flexdis86.OpTable.Parse".
+instance Binary ModConstraint
 
 -- | A value 0-7.
 newtype Fin8 = Fin8 { unFin8 :: Word8 }
-  deriving (Eq, Generic, Lift, Ord, Show)
+  deriving (Eq, Generic, Ord, Show)
 
 instance DS.NFData Fin8
+-- | For "Flexdis86.OpTable.Parse".
+instance Binary Fin8
 
 -- | Project a word to a 'Fin8' if it is between '0' and '7'.
 asFin8 :: Word8 -> Maybe Fin8
@@ -66,9 +73,11 @@ maskFin8 v = Fin8 (v .&. 0x7)
 
 -- | A value 0-63.
 newtype Fin64 = Fin64 { unFin64 :: Word8 }
-  deriving (Eq, Generic, Lift, Ord, Show)
+  deriving (Eq, Generic, Ord, Show)
 
 instance DS.NFData Fin64
+-- | For "Flexdis86.OpTable.Parse".
+instance Binary Fin64
 
 -- | Project a word to a 'Fin64' if it is between '0' and '63'.
 asFin64 :: Word8 -> Maybe Fin64


### PR DESCRIPTION
Fixes #14, at least insofar as it is realistic to do so. Constructing the entire trie at compile-time OOMs. The current approach achieves a good trade-off: mild compile-time and artifact-size increases (except in binaries, which *decrease* in size (!)) for fairly substantial runtime improvements in allocations and CPU time.

## Build & artifact sizes

| Metric | Opt | `main` | `parse-xml-compile-time` | Change |
|--------|-----|---|---|---|
| Build time | `-O0` | 12.3s | 12.6s | ▲+2.4% |
| Build time | `-O1` | 16.5s | 18.0s | ▲+9.1% |
| Build time | `-O2` | 18.2s | 19.8s | ▲+8.8% |
| Peak GHC heap RSS | `-O0` | 78.8 MB | 79.1 MB | ▲+0.4% |
| Peak GHC heap RSS | `-O1` | 113.2 MB | 128.7 MB | ▲+13.6% |
| Peak GHC heap RSS | `-O2` | 117.6 MB | 130.6 MB | ▲+11.1% |
| Static lib (.a) | `-O0` | 3.0 MB | 3.4 MB | ▲+11.5% |
| Static lib (.a) | `-O1` | 3.1 MB | 3.8 MB | ▲+20.8% |
| Static lib (.a) | `-O2` | 3.3 MB | 4.0 MB | ▲+19.7% |
| Shared lib (.so) | `-O0` | 2.2 MB | 2.4 MB | ▲+10.8% |
| Shared lib (.so) | `-O1` | 2.7 MB | 3.2 MB | ▲+19.7% |
| Shared lib (.so) | `-O2` | 2.8 MB | 3.3 MB | ▲+19.0% |
| Test binary | `-O0` | 17.7 MB | 17.4 MB | ▼-1.6% |
| Test binary | `-O1` | 17.5 MB | 17.4 MB | ▼-0.6% |
| Test binary | `-O2` | 17.6 MB | 17.5 MB | ▼-0.7% |

## Test suite (GHC RTS stats, deterministic)

| Metric | Opt | `main` | `parse-xml-compile-time` | Change |
|--------|-----|---|---|---|
| Heap allocated | `-O0` | 1.04 GB | 671.6 MB | ▼-35.5% |
| Heap allocated | `-O1` | 454.3 MB | 151.8 MB | ▼-66.6% |
| Heap allocated | `-O2` | 453.1 MB | 151.0 MB | ▼-66.7% |
| Max live bytes | `-O0` | 22.3 MB | 17.2 MB | ▼-22.8% |
| Max live bytes | `-O1` | 13.8 MB | 15.5 MB | ▲+12.0% |
| Max live bytes | `-O2` | 22.9 MB | 15.5 MB | ▼-32.1% |
| GC CPU time | `-O0` | 0.135s | 0.056s | ▼-58.5% |
| GC CPU time | `-O1` | 0.113s | 0.045s | ▼-60.2% |
| GC CPU time | `-O2` | 0.125s | 0.049s | ▼-60.8% |
| Total CPU time | `-O0` | 0.679s | 0.533s | ▼-21.5% |
| Total CPU time | `-O1` | 0.430s | 0.323s | ▼-24.9% |
| Total CPU time | `-O2` | 0.470s | 0.329s | ▼-30.0% |