### PR TITLE
Sparse trie

### DIFF
--- a/src/Flexdis86/Disassembler.hs
+++ b/src/Flexdis86/Disassembler.hs
@@ -1005,10 +1005,11 @@ disassembleInstruction tr0 = loopPrefixBytes Seq.empty
         go :: NextOpcodeTable -> Word8 -> m InstructionInstance
         go tr opcodeByte =
           case Trie.index tr opcodeByte of
-            OpcodeTable (Trie.Branch tr') -> do
+            Nothing -> invalidInstruction
+            Just (OpcodeTable (Trie.Branch tr')) -> do
               opcodeByte' <- readByte
               go (coerce tr') opcodeByte'
-            OpcodeTable (Trie.Leaf (OpcodeTableEntry defsWithModRM defsWithoutModRM))
+            Just (OpcodeTable (Trie.Leaf (OpcodeTableEntry defsWithModRM defsWithoutModRM)))
               |  -- Check the instruction candidates without a ModR/M byte
                  -- first. If one is found, there is an invariant that none
                  -- of the instruction candidates without a ModR/M byte
@@ -1390,7 +1391,7 @@ disassembleBuffer p bs0 = group 0 (decode bs0 decoder)
 
 opcodeTableSize :: OpcodeTable -> Int
 opcodeTableSize (OpcodeTable (Trie.Branch v)) =
-  sum (opcodeTableSize <$> coerce @(Trie.Vec8 (Trie.Trie8 OpcodeTableEntry)) @(Trie.Vec8 OpcodeTable) v)
+  sum (opcodeTableSize . OpcodeTable <$> v)
 opcodeTableSize (OpcodeTable (Trie.Leaf (OpcodeTableEntry defsWithModRM defsWithoutModRM))) =
   length defsWithModRM + length defsWithoutModRM
 

--- a/src/Flexdis86/Trie.hs
+++ b/src/Flexdis86/Trie.hs
@@ -1,27 +1,92 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Flexdis86.Trie
   ( Vec8
   , generateM
   , index
-  , indexM
   , Trie8(..)
   , mkTrie
   ) where
 
 import qualified Control.DeepSeq as DS
-import           Data.Word (Word8)
+import Data.Bits (popCount, testBit, shiftL, shiftR, (.&.), (.|.))
+import Data.Word (Word8, Word64)
 import qualified Data.Vector as V
 import qualified Data.Vector.Mutable as VM
-import           GHC.Generics (Generic)
+import GHC.Generics (Generic)
 
--- | A 'V.Vector' of exactly 256 elements.
+------------------------------------------------------------------------
+-- Bitmap256
+
+-- | A 256-bit bitmap stored as four 'Word64's.
+data Bitmap256 = Bitmap256 !Word64 !Word64 !Word64 !Word64
+  deriving (Generic, Show)
+
+instance DS.NFData Bitmap256
+
+-- | A 'Bitmap256' with all 256 bits set.
+fullBitmap256 :: Bitmap256
+fullBitmap256 = Bitmap256 maxBound maxBound maxBound maxBound
+{-# INLINE fullBitmap256 #-}
+
+-- | Test whether bit @b@ is set.
+testBit256 :: Bitmap256 -> Word8 -> Bool
+testBit256 (Bitmap256 w0 w1 w2 w3) b =
+  let i = word8ToInt b
+      q = i `shiftR` 6
+      r = i .&. 63
+  in testBit (case q of { 0 -> w0; 1 -> w1; 2 -> w2; _ -> w3 }) r
+{-# INLINE testBit256 #-}
+
+-- | Count the number of set bits strictly below position @b@.
+-- This gives the index into the compact array for a present entry.
+sparseIndex :: Bitmap256 -> Word8 -> Int
+sparseIndex (Bitmap256 w0 w1 w2 w3) b =
+  let i = word8ToInt b
+      q = i `shiftR` 6
+      r = i .&. 63
+      mask = (1 `shiftL` r) - 1
+  in case q of
+       0 -> popCount (w0 .&. mask)
+       1 -> popCount w0 + popCount (w1 .&. mask)
+       2 -> popCount w0 + popCount w1 + popCount (w2 .&. mask)
+       _ -> popCount w0 + popCount w1 + popCount w2 + popCount (w3 .&. mask)
+{-# INLINE sparseIndex #-}
+
+-- | Build a bitmap from a predicate over byte values.
+buildBitmap :: (Word8 -> Bool) -> Bitmap256
+buildBitmap p = Bitmap256 (mkWord 0) (mkWord 64) (mkWord 128) (mkWord 192)
+  where
+    mkWord :: Int -> Word64
+    mkWord base = go 0 0
+      where
+        go :: Word64 -> Int -> Word64
+        go !acc 64 = acc
+        go !acc !bit
+          | p (unsafeIntToWord8 (base + bit)) = go (acc .|. (1 `shiftL` bit)) (bit + 1)
+          | otherwise = go acc (bit + 1)
+
+------------------------------------------------------------------------
+-- Vec8
+
+-- | A sparse vector indexed by 'Word8', backed by a bitmap and a
+-- compact array of only the present entries.
 --
--- Named analogously to 'Word8': 8 bits, 256 elements.
-newtype Vec8 a = Vec8 (V.Vector a)
-  deriving (Foldable, Functor, Generic, DS.NFData, Show)
+-- Named analogously to 'Word8': 8 bits, up to 256 elements.
+data Vec8 a = Vec8 !Bitmap256 !(V.Vector a)
+  deriving (Generic, Show)
+
+instance Functor Vec8 where
+  fmap f (Vec8 bm arr) = Vec8 bm (V.map f arr)
+
+instance Foldable Vec8 where
+  foldr f z (Vec8 _ arr) = V.foldr f z arr
+  foldl' f z (Vec8 _ arr) = V.foldl' f z arr
+  length (Vec8 _ arr) = V.length arr
+  null (Vec8 _ arr) = V.null arr
+
+instance DS.NFData a => DS.NFData (Vec8 a)
 
 -- Can truncate in general, but all uses in this module are safe
 unsafeIntToWord8 :: Int -> Word8
@@ -33,39 +98,30 @@ word8ToInt :: Word8 -> Int
 word8ToInt = fromIntegral
 {-# INLINE word8ToInt #-}
 
-generate :: (Word8 -> a) -> Vec8 a
-generate f = Vec8 (V.generate 256 (f . unsafeIntToWord8))
-{-# INLINE generate #-}
-
 generateM :: Monad m => (Word8 -> m a) -> m (Vec8 a)
-generateM f = Vec8 <$> V.generateM 256 (f . unsafeIntToWord8)
+generateM f = Vec8 fullBitmap256 <$> V.generateM 256 (f . unsafeIntToWord8)
 {-# INLINE generateM #-}
 
--- | Index into the 'Vec8' to retrieve an element.
---
--- This uses unsafe indexing internally since we know:
---
--- 1. The underlying 'Vec.Vector' has exactly 256 elements (0x00 to 0xFF)
--- 2. 'Word8' values are always in the range @[0, 255]@
---
--- Therefore, the index is always in bounds and the bounds check is redundant.
-index :: Vec8 a -> Word8 -> a
-index (Vec8 vec) byte = V.unsafeIndex vec (word8ToInt byte)
+-- | Look up a byte index.  Returns 'Nothing' for absent entries.
+index :: Vec8 a -> Word8 -> Maybe a
+index (Vec8 bm arr) byte
+  | testBit256 bm byte = Just $! V.unsafeIndex arr (sparseIndex bm byte)
+  | otherwise = Nothing
 {-# INLINE index #-}
 
--- | Monadic version of 'indexByteCache' that is strict in the vector.
-indexM :: Monad m => Vec8 a -> Word8 -> m a
-indexM (Vec8 vec) byte = V.unsafeIndexM vec (word8ToInt byte)
-{-# INLINE indexM #-}
+------------------------------------------------------------------------
+-- Trie8
 
--- | Split entries based on first identifier in list of bytes.
-partitionBy :: [([Word8], a)] -> Vec8 [([Word8], a)]
-partitionBy l = Vec8 $ V.create $ do
+-- | Split entries based on first byte in the key.
+-- Returns a plain 256-element vector (used only during trie
+-- construction).
+partitionBy :: [([Word8], a)] -> V.Vector [([Word8], a)]
+partitionBy l = V.create $ do
   mv <- VM.replicate 256 []
-  let  go ([], _d) = pure ()
-       go (w:wl,d) = do
-         el <- VM.read mv (word8ToInt w)
-         VM.write mv (word8ToInt w) ((wl,d):el)
+  let go ([], _d) = pure ()
+      go (w:wl, d) = do
+        el <- VM.read mv (word8ToInt w)
+        VM.write mv (word8ToInt w) ((wl, d) : el)
   mapM_ go l
   return mv
 
@@ -73,8 +129,8 @@ partitionBy l = Vec8 $ V.create $ do
 --
 -- Named analogously to 'Word8': 8 bits, 256 elements.
 data Trie8 a
-   = Branch !(Vec8 (Trie8 a))
-   | Leaf !a
+  = Branch !(Vec8 (Trie8 a))
+  | Leaf !a
   deriving (Generic, Show)
 
 instance DS.NFData a => DS.NFData (Trie8 a)
@@ -85,11 +141,10 @@ mkTrie :: ([a] -> b) -> [([Word8], a)] -> Trie8 b
 mkTrie mkLeaf l
   | all done l = Leaf (mkLeaf (snd <$> l))
   | otherwise =
-    let v = partitionBy l
-        g i = mkTrie mkLeaf (v `index` i)
-        tbl = generate g
-    in Branch tbl
+    let parts = partitionBy l
+        bm = buildBitmap (\w -> not (null (parts V.! word8ToInt w)))
+        arr = V.map (mkTrie mkLeaf) (V.filter (not . null) parts)
+    in Branch (Vec8 bm arr)
   where
     done :: ([Word8], a) -> Bool
     done (remaining, _) = null remaining
-


### PR DESCRIPTION
Replace the always-256-element `Vector` in `Vec8` with a sparse representation: a 256-bit bitmap and a compact array of only the present entries. Absent byte values return `Nothing` from index, and the disassembler treats them as invalid instructions.

Measurements indicate that the trie is *very* sparse: 2,229 Branch nodes with an average population of 6 out of 256 (97.7% empty). When forced, the trie is 32 MB with the dense representation. In the sparse representation, it's 5.3 MB. This isn't astronomical, but it may have secondary effects on cache locality.

Unfortunately, I haven't gotten great benchmark results yet - the small benchmarks barely force the table, and larger ones are dominated by other costs. Will try more detailed profiling and report results.