### PR TITLE
perf: Packed VEX prefixes

### DIFF
--- a/flexdis86.cabal
+++ b/flexdis86.cabal
@@ -50,8 +50,10 @@ library
     Flexdis86.OpTable.Parse
     Flexdis86.Prefixes.Allowed
     Flexdis86.Prefixes.Code
+    Flexdis86.Prefixes.REX
     Flexdis86.Prefixes.Required
     Flexdis86.Prefixes.Seen
+    Flexdis86.Prefixes.VEX
     Flexdis86.Trie
   ghc-options: -Wall -fno-ignore-asserts -O2 -Wno-trustworthy-safe
 

--- a/src/Flexdis86/Assembler.hs
+++ b/src/Flexdis86/Assembler.hs
@@ -46,7 +46,9 @@ import           Flexdis86.Operand
 import           Flexdis86.OpTable
 import           Flexdis86.InstructionSet
 import           Flexdis86.Prefixes
+import           Flexdis86.Prefixes.REX ( REX(..), rexB, rexR, rexW )
 import           Flexdis86.Prefixes.Required ( Required, noRequired, requiredToByte )
+import           Flexdis86.Prefixes.VEX ( hasVex, noVex )
 import           Flexdis86.Register
 import           Flexdis86.Segment
 import           Flexdis86.Sizes
@@ -96,7 +98,7 @@ findEncoding args def = do
   let oso = mkOSO def argTypes
   F.forM_ argTypes $ \at -> guard (matchOperandType oso at)
   let rex = mkREX argTypes
-  let vex = Nothing -- XXX: implement this
+  let vex = noVex -- XXX: implement this
   let notrack = False -- for now, not trying to use this feature
   return $ II { iiLockPrefix = NoLockPrefix
               -- ???: why is this always Size16? Can we do better
@@ -358,7 +360,7 @@ mkAssembledInstruction ::
   InstructionInstance ->
   m (AssembledInstruction B.Builder)
 mkAssembledInstruction ii = do
-  when (isJust (L.view prVEX pfxs)) $ do
+  when (hasVex (L.view prVEX pfxs)) $ do
     C.throwM VEXUnsupported
   mdisp <- encodeModRMDisp ii
   return $

--- a/src/Flexdis86/Disassembler.hs
+++ b/src/Flexdis86/Disassembler.hs
@@ -60,8 +60,10 @@ import           Flexdis86.InstructionSet
 import           Flexdis86.OpTable
 import           Flexdis86.Operand
 import           Flexdis86.Prefixes
+import           Flexdis86.Prefixes.REX (REX(..), rexW, unREX)
 import           Flexdis86.Prefixes.Required (noRequired, requiredToByte)
 import           Flexdis86.Prefixes.Seen (Seen, emptySeen, addPrefix, materializePrefixes, checkAllowed)
+import           Flexdis86.Prefixes.VEX (VEX, noVex, hasVex, mkVEX2, mkVEX3, vex256, vexRex, vexVVVV)
 import           Flexdis86.Register
 import           Flexdis86.Segment
 import           Flexdis86.Sizes
@@ -337,7 +339,7 @@ data RegTable a
 
 instance DS.NFData a => DS.NFData (RegTable a)
 
-type RMTable = RegTable [(Maybe VEX, Def)]
+type RMTable = RegTable [(VEX, Def)]
 
 data ModTable
      -- | @ModTable memTable regTable@
@@ -355,7 +357,7 @@ instance DS.NFData ModTable
 data OpcodeTableEntry
   = OpcodeTableEntry
       !(RegTable ModTable) -- Defs expecting a ModR/M byte
-      ![(Maybe VEX, Def)]  -- Defs not expecting a ModR/M byte
+      ![(VEX, Def)]        -- Defs not expecting a ModR/M byte
   deriving (Generic, Show)
 
 instance DS.NFData OpcodeTableEntry
@@ -369,7 +371,7 @@ newtype OpcodeTable = OpcodeTable (Trie.Trie8 OpcodeTableEntry)
 -- | A NextOpcodeTable describes a table of parsers to read based on the bytes.
 type NextOpcodeTable = Trie.Vec8 OpcodeTable
 
-type DefTableFn t = [(Maybe VEX, Def)] -> t
+type DefTableFn t = [(VEX, Def)] -> t
 -- ^ Given a list of pairs of VEX prefixes and definitions, build a table of
 -- possible instructions.
 
@@ -496,13 +498,13 @@ nonVexPrefixBytes = HS.unions
 -- particular.) Each element of the returned list consists of a pair where
 -- the first part of the pair contains the raw bytes, and the second part of
 -- the pair contains the corresponding 'VEX' (if one exists) and 'Def'.
-allVexPrefixesAndOpcodes :: Def -> [([Word8], (Maybe VEX, Def))]
+allVexPrefixesAndOpcodes :: Def -> [([Word8], (VEX, Def))]
 allVexPrefixesAndOpcodes def
   | null (def ^. vexPrefixes)
-  = [ (def^.defOpcodes, (Nothing, def)) ]
+  = [ (def^.defOpcodes, (noVex, def)) ]
 
   | otherwise
-  = [ (vexBytes ++ def^.defOpcodes, (Just vex, def))
+  = [ (vexBytes ++ def^.defOpcodes, (vex, def))
     | (vexBytes, vex) <- mkVexPrefixes def ]
   where
     mkVexPrefixes :: Def -> [([Word8], VEX)]
@@ -510,8 +512,8 @@ allVexPrefixesAndOpcodes def
       where
       cvt pref =
         case pref of
-          [ _, b ]      -> (pref, VEX2 b)
-          [ _, b1, b2 ] -> (pref, VEX3 b1 b2)
+          [ _, b ]      -> (pref, mkVEX2 b)
+          [ _, b1, b2 ] -> (pref, mkVEX3 b1 b2)
           _             -> error "mkVexPrefixes: unexpected byte sequence"
 
 -- | Given a list of instruction 'Def's, compute a lookup table for its VEX
@@ -521,7 +523,7 @@ mkOpcodeTable :: [Def] -> OpcodeTable
 mkOpcodeTable defs =
   OpcodeTable (Trie.mkTrie mkLeaf (concatMap allVexPrefixesAndOpcodes defs))
   where
-    mkLeaf :: [(Maybe VEX, Def)] -> OpcodeTableEntry
+    mkLeaf :: [(VEX, Def)] -> OpcodeTableEntry
     mkLeaf vexDefs =
       let (defsWithModRM, defsWithoutModRM) = partition (expectsModRM . snd) vexDefs
       in OpcodeTableEntry (checkRequiredReg defsWithModRM) defsWithoutModRM
@@ -587,7 +589,7 @@ mkFin8Vector f = V.generate 8 g
             Nothing -> error $ "internal: Expected number between 0-7, received " ++ show i
 
 -- | Return true if the definition matches the Fin8 constraint
-matchRMConstraint :: Fin8 -> (Maybe VEX,Def) -> Bool
+matchRMConstraint :: Fin8 -> (VEX,Def) -> Bool
 matchRMConstraint i (_,d) = i `matchesMaybeFin8` (d^.requiredRM)
 
 -- | Check required RM if needed, then forward to final table.
@@ -620,7 +622,7 @@ read_disp8 = Disp8 <$> readSByte
 parseReadTable :: ByteReader m
                => Seen
                -> ModRM
-               -> [(Maybe VEX, Def)]
+               -> [(VEX, Def)]
                -> m InstructionInstance
 parseReadTable pc modRM dfs = do
   (pfx, df) <- matchDefWithSeen pc dfs
@@ -643,7 +645,7 @@ parseReadTable pc modRM dfs = do
 getReadTable ::
   ModRM ->
   RMTable ->
-  [(Maybe VEX, Def)]
+  [(VEX, Def)]
 getReadTable modRM (RegTable v) = v V.! fromIntegral (modRM_rm modRM)
 getReadTable _modRM (RegUnchecked m) = m
 
@@ -671,7 +673,7 @@ getRMTable modRM mtbl =
 -- with identical opcodes, and no more than that.
 validateSeen ::
   Seen ->
-  Maybe VEX ->
+  VEX ->
   Def ->
   Either String (Prefixes, Def)
 validateSeen pc mbVex def
@@ -749,7 +751,7 @@ data DefSearchError
 -- encountered), return 'Left'.
 findDefWithSeen ::
   Seen ->
-  [(Maybe VEX, Def)] ->
+  [(VEX, Def)] ->
   Either DefSearchError (Prefixes, Def)
 findDefWithSeen pc defs =
   case mapMaybe match defs of
@@ -758,7 +760,7 @@ findDefWithSeen pc defs =
     res@(_:_:_) -> Left $ MultipleDefsFound
                         $ map (BSC.unpack . view defMnemonic . snd) res
   where
-    match :: (Maybe VEX, Def) -> Maybe (Prefixes, Def)
+    match :: (VEX, Def) -> Maybe (Prefixes, Def)
     match (mbVex, def) =
       case validateSeen pc mbVex def of
         Left _err    -> Nothing
@@ -769,7 +771,7 @@ findDefWithSeen pc defs =
 matchDefWithSeen ::
   ByteReader m =>
   Seen ->
-  [(Maybe VEX, Def)] ->
+  [(VEX, Def)] ->
   m (Prefixes, Def)
 matchDefWithSeen pc defs =
   case findDefWithSeen pc defs of
@@ -900,9 +902,10 @@ memSizeFn osz sz =
 
 
 getREX :: Prefixes -> REX
-getREX p = case p ^. prVEX of
-             Just vex -> vex ^. vexRex
-             _        -> p ^. prREX
+getREX p
+  | hasVex vex = vexRex vex
+  | otherwise  = p ^. prREX
+  where vex = p ^. prVEX
 
 readOffset :: ByteReader m => Segment -> Bool -> m AddrRef
 readOffset s aso
@@ -951,8 +954,9 @@ parseValue p osz mmrm tp = do
     OpType (Opcode_reg r) sz -> pure $ regSizeFn osz rex sz (rex_b rex .|. r)
     OpType (Reg_fixed r) sz  -> pure $ regSizeFn osz rex sz r
     OpType VVVV sz
-      | Just vx <- p ^. prVEX -> pure $ regSizeFn osz rex sz $ complement (vx ^. vexVVVV) .&. 0xF
+      | hasVex vx -> pure $ regSizeFn osz rex sz $ complement (vexVVVV vx) .&. 0xF
       | otherwise -> error "[VVVV_XMM] Missing VEX prefix "
+      where vx = p ^. prVEX
     OpType ImmediateSource BSize ->
       ByteImm <$> readByte
     OpType ImmediateSource WSize ->
@@ -1002,15 +1006,17 @@ parseValue p osz mmrm tp = do
       | Just sz <- mb     -> error ("[RM_XMM] Unexpected size: " ++ show sz)
 
       | Nothing <- mb
-      , Just vx <- p ^. prVEX
-      , vx ^. vex256      -> Mem256 <$> addr
+      , let vx = p ^. prVEX
+      , hasVex vx
+      , vex256 vx         -> Mem256 <$> addr
 
       | otherwise         -> Mem128 <$> addr
 
     VVVV_XMM mb
-      | Just vx <- p ^. prVEX ->
-          return $ largeReg p mb $ complement (vx ^. vexVVVV) .&. 0xF
+      | hasVex vx ->
+          return $ largeReg p mb $ complement (vexVVVV vx) .&. 0xF
       | otherwise -> error "[VVVV_XMM] Missing VEX prefix "
+      where vx = p ^. prVEX
 
     SEG s -> return $ SegmentValue s
     M_FP -> FarPointer <$> addr
@@ -1067,9 +1073,10 @@ largeReg :: Prefixes -> Maybe OperandSize -> Word8 -> Value
 largeReg p mb num =
   case mb of
 
-    Nothing | Just vx <- p ^. prVEX
-            , vx ^. vex256  -> useYMM
-            | otherwise     -> useXMM
+    Nothing | let vx = p ^. prVEX
+            , hasVex vx
+            , vex256 vx  -> useYMM
+            | otherwise  -> useXMM
 
     Just sz ->
       case sz of
@@ -1195,15 +1202,15 @@ disassembleBuffer p bs0 = group 0 (decode bs0 decoder)
 
 -- | Flatten all candidate defs stored in a 'RegTable' 'ModTable' into a
 -- list. Used by decoder assertions and for size accounting.
-flattenRegTable :: RegTable ModTable -> [(Maybe VEX, Def)]
+flattenRegTable :: RegTable ModTable -> [(VEX, Def)]
 flattenRegTable (RegUnchecked mt) = flattenModTable mt
 flattenRegTable (RegTable v) = concatMap flattenModTable (V.toList v)
 
-flattenModTable :: ModTable -> [(Maybe VEX, Def)]
+flattenModTable :: ModTable -> [(VEX, Def)]
 flattenModTable (ModUnchecked rm) = flattenRMTable rm
 flattenModTable (ModTable m r) = flattenRMTable m ++ flattenRMTable r
 
-flattenRMTable :: RMTable -> [(Maybe VEX, Def)]
+flattenRMTable :: RMTable -> [(VEX, Def)]
 flattenRMTable (RegUnchecked xs) = xs
 flattenRMTable (RegTable v) = concat (V.toList v)
 

--- a/src/Flexdis86/Prefixes.hs
+++ b/src/Flexdis86/Prefixes.hs
@@ -12,11 +12,6 @@ Defines prefix operations.
 
 module Flexdis86.Prefixes
   ( Prefixes(..)
-  , REX(..)
-  , rexW
-  , rexR
-  , rexB
-  , rexX
   , SegmentPrefix(..)
   , prLockPrefix
   , prSP
@@ -43,10 +38,6 @@ module Flexdis86.Prefixes
   , setDefault
   , LockPrefix(..)
   , ppLockPrefix
-  , VEX(..)
-  , vexRex
-  , vexVVVV
-  , vex256
   ) where
 
 import qualified Control.DeepSeq as DS
@@ -56,8 +47,9 @@ import           GHC.Generics
 import           Lens.Micro (Lens', lens, (^.))
 import           Numeric ( showHex )
 import qualified Prettyprinter as PP
-import           Text.Printf
 
+import           Flexdis86.Prefixes.REX (REX)
+import           Flexdis86.Prefixes.VEX (VEX)
 import           Flexdis86.Segment
 import           Flexdis86.Sizes
 
@@ -151,46 +143,6 @@ ppLockPrefix RepNZPrefix = "repnz"
 -----------------------------------------------------------------------
 -- REX
 
--- | REX value for 64-bit mode.
-newtype REX = REX { unREX :: Word8 }
-  deriving (Eq, Generic)
-
-instance DS.NFData REX
-
-setBitTo :: (B.Bits b) => b -> Int -> Bool -> b
-setBitTo bits bitNo val
-  | val = B.setBit bits bitNo
-  | otherwise = B.clearBit bits bitNo
-
--- | Indicates if 64-bit operand size should be used.
-rexW :: Lens' REX Bool
-rexW = lens ((`B.testBit` 3) . unREX) (\(REX r) v -> REX (setBitTo r 3 v))
-
--- | Extension of ModR/M reg field.
-rexR :: Lens' REX Bool
-rexR = lens ((`B.testBit` 2) . unREX) (\(REX r) v -> REX (setBitTo r 2 v))
-
--- | Extension of SIB index field.
-rexX :: Lens' REX Bool
-rexX = lens ((`B.testBit` 1) . unREX) (\(REX r) v -> REX (setBitTo r 1 v))
-
--- | Extension of ModR/M r/m field, SIB base field, or Opcode reg field.
-rexB :: Lens' REX Bool
-rexB = lens ((`B.testBit` 0) . unREX) (\(REX r) v -> REX (setBitTo r 0 v))
-
-instance Show REX where
-  show (REX rex) = printf "0b%08b" rex
-
-
------------------------------------------------------------------------
--- VEX
-
-data VEX = VEX2 Word8{-1-}              -- ^ Byte of a 2-byte VEX prefix
-         | VEX3 Word8{-1-} Word8{-2-}   -- ^ Byte 1 and 2 of 3-byte VEX prefix
-           deriving (Eq, Generic, Show)
-
-instance DS.NFData VEX
-
 -----------------------------------------------------------------------
 -- Prefixes
 
@@ -198,7 +150,7 @@ instance DS.NFData VEX
 data Prefixes = Prefixes { _prLockPrefix :: !LockPrefix
                          , _prSP  :: !SegmentPrefix
                          , _prREX :: !REX
-                         , _prVEX :: !(Maybe VEX)
+                         , _prVEX :: !VEX
                          , _prASO :: !Bool
                          , _prOSO :: !Bool
                          , _prNoTrack :: !Bool
@@ -206,51 +158,6 @@ data Prefixes = Prefixes { _prLockPrefix :: !LockPrefix
                 deriving (Eq, Generic, Show)
 
 instance DS.NFData Prefixes
-
-vexLens :: (Word8 -> a) ->
-           (Word8 -> Word8 -> a) ->
-           (Word8 -> a -> Word8) ->
-           (Word8 -> Word8 -> a -> (Word8,Word8)) ->
-           Lens' VEX a
-vexLens get1 get2 upd1 upd2 = lens getter updater
-  where getter vex = case vex of
-                       VEX2 b     -> get1 b
-                       VEX3 b1 b2 -> get2 b1 b2
-        updater old a = case old of
-                          VEX2 b     -> VEX2 (upd1 b a)
-                          VEX3 b1 b2 -> let (b1',b2') = upd2 b1 b2 a
-                                        in VEX3 b1' b2'
-
--- | Are we using 256-bit vectors
-vex256 :: Lens' VEX Bool
-vex256 = vexLens gt (\_ b2 -> gt b2)
-                 st (\b1 b2 a -> (b1, st b2 a))
-  where
-  gt b   = B.testBit b 2
-  st b v = if v then B.setBit b 2 else B.clearBit b 2
-
-
--- | REX info from VEX prefix
-vexRex :: Lens' VEX REX
-vexRex = vexLens gt1 gt2 st1 st2
-  where
-  gt1 b      = REX (0x40 B..|. B.shiftR (B.complement b B..&. 0x80) 5)
-  gt2 b1 b2  = REX (0x40 B..|. B.shiftR (B.complement b2 B..&. 0x80) 4
-                         B..|. B.shiftR (B.complement b1 B..&. 0xE0) 5)
-
-  st1 b v     = if v ^. rexR then B.clearBit b 7 else B.setBit b 7
-  st2 b1 b2 v = ( (b1 B..&. 0x1F) B..|. (B.complement (unREX v) `B.shiftL` 5)
-                , if v ^. rexW then B.clearBit b2 7 else B.setBit b2 7
-                )
-
--- | The VVVV field.  We return it as is.  Note that when used to encode
--- registers, the byte needs to be complemented.
-vexVVVV :: Lens' VEX Word8
-vexVVVV = vexLens gt (\_ b2 -> gt b2)
-                  st (\b1 b2 v -> (b1, st b2 v))
-  where
-  gt b   = B.shiftR b 3 B..&. 0xF
-  st b v = (b B..&. 0x87) B..|. B.shiftL (v B..&. 0xF) 3
 
 prLockPrefix :: Lens' Prefixes LockPrefix
 prLockPrefix = lens _prLockPrefix (\s v -> s { _prLockPrefix = v })
@@ -261,7 +168,7 @@ prSP = lens _prSP (\s v -> s { _prSP = v})
 prREX :: Lens' Prefixes REX
 prREX = lens _prREX (\s v -> s { _prREX = v })
 
-prVEX :: Lens' Prefixes (Maybe VEX)
+prVEX :: Lens' Prefixes VEX
 prVEX = lens _prVEX (\s v -> s { _prVEX = v })
 
 prASO :: Lens' Prefixes Bool

--- a/src/Flexdis86/Prefixes/REX.hs
+++ b/src/Flexdis86/Prefixes/REX.hs
@@ -1,0 +1,53 @@
+{- |
+Module      : Flexdis86.Prefixes.REX
+Copyright   : (c) Galois, Inc, 2026
+
+The @REX@ prefix byte and its bit lenses.
+-}
+
+{-# LANGUAGE DeriveGeneric #-}
+
+module Flexdis86.Prefixes.REX
+  ( REX(..)
+  , rexW
+  , rexR
+  , rexX
+  , rexB
+  ) where
+
+import qualified Control.DeepSeq as DS
+import qualified Data.Bits as B
+import           Data.Word (Word8)
+import           GHC.Generics
+import           Lens.Micro (Lens', lens)
+import           Text.Printf
+
+-- | REX value for 64-bit mode.
+newtype REX = REX { unREX :: Word8 }
+  deriving (Eq, Generic)
+
+instance DS.NFData REX
+
+setBitTo :: (B.Bits b) => b -> Int -> Bool -> b
+setBitTo bits bitNo val
+  | val = B.setBit bits bitNo
+  | otherwise = B.clearBit bits bitNo
+
+-- | Indicates if 64-bit operand size should be used.
+rexW :: Lens' REX Bool
+rexW = lens ((`B.testBit` 3) . unREX) (\(REX r) v -> REX (setBitTo r 3 v))
+
+-- | Extension of ModR/M reg field.
+rexR :: Lens' REX Bool
+rexR = lens ((`B.testBit` 2) . unREX) (\(REX r) v -> REX (setBitTo r 2 v))
+
+-- | Extension of SIB index field.
+rexX :: Lens' REX Bool
+rexX = lens ((`B.testBit` 1) . unREX) (\(REX r) v -> REX (setBitTo r 1 v))
+
+-- | Extension of ModR/M r/m field, SIB base field, or Opcode reg field.
+rexB :: Lens' REX Bool
+rexB = lens ((`B.testBit` 0) . unREX) (\(REX r) v -> REX (setBitTo r 0 v))
+
+instance Show REX where
+  show (REX rex) = printf "0b%08b" rex

--- a/src/Flexdis86/Prefixes/Seen.hs
+++ b/src/Flexdis86/Prefixes/Seen.hs
@@ -28,7 +28,9 @@ import           Data.Word (Word8, Word16, Word64)
 import           Flexdis86.Prefixes
 import           Flexdis86.Prefixes.Allowed
 import           Flexdis86.Prefixes.Code
+import           Flexdis86.Prefixes.REX (REX(..))
 import           Flexdis86.Prefixes.Required
+import           Flexdis86.Prefixes.VEX (VEX, hasVex)
 
 -- | What prefix bytes have been observed in the byte stream. Wraps a
 -- 'PrefixCode'; see "Flexdis86.Prefixes.Code" for the bit layout. The
@@ -140,8 +142,8 @@ lookupSegByte pc@(PrefixCode w_) =
 -- 'Flexdis86.OpTable.defPrefix', which already has the required-prefix
 -- bit OR'd in at parse time), so 'containedIn' can be a single bitwise
 -- test.
-checkAllowed :: Seen -> Maybe VEX -> Allowed -> Required -> Bool
-checkAllowed (Seen seen) mbVex allowed req =
+checkAllowed :: Seen -> VEX -> Allowed -> Required -> Bool
+checkAllowed (Seen seen) vex allowed req =
   seen `containedIn` allowedCode allowed && requiredSeen && rexVexDisjoint
   where
     -- A def with a required prefix only validates when that bit was
@@ -151,9 +153,7 @@ checkAllowed (Seen seen) mbVex allowed req =
       in rc == zeroBits || seen .&. rc /= zeroBits
 
     -- Having both REX and VEX prefixes is #UD.
-    rexVexDisjoint = seen .&. rexSeenBit == zeroBits || case mbVex of
-      Nothing -> True
-      Just _  -> False
+    rexVexDisjoint = seen .&. rexSeenBit == zeroBits || not (hasVex vex)
 {-# INLINE checkAllowed #-}
 
 -- | Reconstruct a 'Prefixes' value from the observed prefixes, the VEX
@@ -172,12 +172,12 @@ checkAllowed (Seen seen) mbVex allowed req =
 --  * Segment/notrack (0x3E): materializes as a notrack flag if the def's
 --    allowed set has @notrack@ semantics ('notrackSemanticBit') without
 --    allowing any segment override; otherwise it is a DS segment override.
-materializePrefixes :: Seen -> Maybe VEX -> Allowed -> Required -> Prefixes
-materializePrefixes (Seen seen) mbVex allowed req = Prefixes
+materializePrefixes :: Seen -> VEX -> Allowed -> Required -> Prefixes
+materializePrefixes (Seen seen) vex allowed req = Prefixes
   { _prLockPrefix = lockPrefix
   , _prSP = SegmentPrefix segByte
   , _prREX = REX rexByte
-  , _prVEX = mbVex
+  , _prVEX = vex
   , _prASO = legacy .&. asoBit /= zeroBits
   , _prOSO = legacy .&. osoBit /= zeroBits
   , _prNoTrack = asNotrack

--- a/src/Flexdis86/Prefixes/VEX.hs
+++ b/src/Flexdis86/Prefixes/VEX.hs
@@ -1,0 +1,151 @@
+{- |
+Module      : Flexdis86.Prefixes.VEX
+Copyright   : (c) Galois, Inc, 2026
+
+Packed @VEX@ prefix, stored as two raw bytes inside a single 'Word16'.
+Every constructed 'VEX' is in canonical VEX3 form: two-byte VEX
+observations ('mkVEX2') are normalized on entry by filling in the
+implicit @~X=1@, @~B=1@, @W=0@, @m-mmmm=00001@ fields. Callers read
+individual fields with inline bit operations - no branches on
+VEX2\/VEX3.
+
+The sentinel 'noVex' ('VEX' @0@) means \"no VEX prefix observed.\" No
+valid VEX encoding can alias this: a real VEX3 byte 1 has
+@m-mmmm \\in \\{1, 2, 3\\}@, so its low five bits are always nonzero.
+
+Bit layout (little-endian into the 'Word16'):
+
+@
+  byte 0 (low) - VEX3 byte 1
+    [7]     ~R
+    [6]     ~X
+    [5]     ~B
+    [4:0]   m-mmmm    (1=0x0F, 2=0x0F 38, 3=0x0F 3A)
+
+  byte 1 (high) - VEX3 byte 2
+    [7]     W
+    [6:3]   ~vvvv
+    [2]     L         (0 = 128-bit, 1 = 256-bit)
+    [1:0]   pp        (implied SIMD prefix)
+@
+-}
+
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Flexdis86.Prefixes.VEX
+  ( VEX(..)
+  , noVex
+  , hasVex
+  , mkVEX2
+  , mkVEX3
+    -- * Accessors
+  , vexRex
+  , vexVVVV
+  , vex256
+  , vexByte1
+  , vexByte2
+  ) where
+
+import           Control.Exception (assert)
+import qualified Control.DeepSeq as DS
+import           Data.Binary (Binary)
+import           Data.Bits ( (.&.), (.|.), complement, shiftL, shiftR
+                           , testBit
+                           )
+import           Data.Word (Word8, Word16)
+
+import           Flexdis86.Prefixes.REX (REX(..))
+
+-- | Packed VEX prefix. @'VEX' 0@ is the distinguished \"no VEX\"
+-- value; any other 'Word16' encodes a VEX3-normalized pair of raw VEX
+-- bytes. See the module haddock for the exact layout.
+newtype VEX = VEX Word16
+  deriving (Binary, DS.NFData, Eq, Ord, Show)
+
+-- | The \"no VEX prefix observed\" sentinel. Equal to @'VEX' 0@;
+-- compare with @== 'noVex'@ or @/= 'noVex'@ to branch on presence.
+noVex :: VEX
+noVex = VEX 0
+{-# INLINE noVex #-}
+
+-- | Is a VEX prefix present?
+hasVex :: VEX -> Bool
+hasVex v = v /= noVex
+{-# INLINE hasVex #-}
+
+-- | Build a 'VEX' from a two-byte-VEX (0xC5) payload. The payload is
+-- promoted to the equivalent VEX3 form in-place: @~X=1@, @~B=1@,
+-- @W=0@, @m-mmmm=00001@. The payload's @~R@ bit carries over to byte
+-- 1's @~R@ position; the rest of the payload (vvvv, L, pp, W=0) lands
+-- verbatim in byte 2.
+mkVEX2 :: Word8 -> VEX
+mkVEX2 payload =
+  -- byte 1: ~R from payload bit 7, ~X=1 (bit 6), ~B=1 (bit 5),
+  --         m-mmmm=00001 (bits 4..0).
+  --         @(payload .&. 0x80) .|. 0x61@.
+  -- byte 2: bit 7 is W; VEX2 implies W=0, so clear the payload's bit 7.
+  let b1 = (payload .&. 0x80) .|. 0x61
+      b2 = payload .&. 0x7F
+  in packBytes b1 b2
+{-# INLINE mkVEX2 #-}
+
+-- | Build a 'VEX' from a three-byte-VEX (0xC4) payload.
+mkVEX3 :: Word8 -> Word8 -> VEX
+mkVEX3 b1 b2 = packBytes b1 b2
+{-# INLINE mkVEX3 #-}
+
+packBytes :: Word8 -> Word8 -> VEX
+packBytes b1 b2 =
+  VEX (fromIntegral @Word8 @Word16 b1 .|. (fromIntegral @Word8 @Word16 b2 `shiftL` 8))
+{-# INLINE packBytes #-}
+
+-- | Raw VEX3 byte 1. Zero when 'hasVex' is 'False'.
+vexByte1 :: VEX -> Word8
+vexByte1 (VEX w) = fromIntegral @Word16 @Word8 w
+{-# INLINE vexByte1 #-}
+
+-- | Raw VEX3 byte 2. Zero when 'hasVex' is 'False'.
+vexByte2 :: VEX -> Word8
+vexByte2 (VEX w) = fromIntegral @Word16 @Word8 (w `shiftR` 8)
+{-# INLINE vexByte2 #-}
+
+------------------------------------------------------------------------
+-- Accessors
+--
+-- For a canonical VEX3 encoding (which is what we always store), the
+-- REX, vvvv, L, and pp fields are pure bit extractions. No case on
+-- VEX2 vs VEX3 is needed because 'mkVEX2' fills in VEX3's implicit
+-- fields.
+
+-- | The implied REX byte. Combines @~R@\/@~X@\/@~B@ from byte 1 and
+-- @W@ from byte 2, inverting and shifting into the REX byte's
+-- @0b0100WRXB@ layout.
+--
+-- Precondition: 'hasVex'. Asserted, but not checked in production.
+vexRex :: VEX -> REX
+vexRex v@(VEX w) =
+  assert (hasVex v) $
+  let b1 = fromIntegral @Word16 @Word8 w
+      b2 = fromIntegral @Word16 @Word8 (w `shiftR` 8)
+  in REX ( 0x40
+      .|. (complement b2 .&. 0x80) `shiftR` 4         -- W from byte 2 bit 7 -> REX bit 3
+      .|. (complement b1 .&. 0xE0) `shiftR` 5         -- ~R ~X ~B -> REX bits 2..0
+         )
+{-# INLINE vexRex #-}
+
+-- | The 4-bit @vvvv@ source register (de-inverted). Callers that
+-- interpret it as a register index typically complement and mask.
+--
+-- Precondition: 'hasVex'. Asserted, but not checked in production.
+vexVVVV :: VEX -> Word8
+vexVVVV v = assert (hasVex v) $ (vexByte2 v `shiftR` 3) .&. 0xF
+{-# INLINE vexVVVV #-}
+
+-- | Is this a 256-bit vector operation (L bit of byte 2)?
+--
+-- Precondition: 'hasVex'. Asserted, but not checked in production.
+vex256 :: VEX -> Bool
+vex256 v = assert (hasVex v) $ testBit (vexByte2 v) 2
+{-# INLINE vex256 #-}


### PR DESCRIPTION
Pack VEX prefixes into a single `Word16` instead of a boxed `Maybe` of a boxed enum.