### PR TITLE
perf: Take VEX prefixes out of the trie

### DIFF
--- a/flexdis86.cabal
+++ b/flexdis86.cabal
@@ -50,9 +50,12 @@ library
     Flexdis86.OpTable.Parse
     Flexdis86.Prefixes.Allowed
     Flexdis86.Prefixes.Code
+    Flexdis86.Prefixes.REX
     Flexdis86.Prefixes.Required
     Flexdis86.Prefixes.Seen
     Flexdis86.Trie
+    Flexdis86.VEX.Allowed
+    Flexdis86.VEX.Seen
   ghc-options: -Wall -fno-ignore-asserts -O2 -Wno-trustworthy-safe
 
 executable DumpInstr

--- a/src/Flexdis86/Assembler.hs
+++ b/src/Flexdis86/Assembler.hs
@@ -46,7 +46,9 @@ import           Flexdis86.Operand
 import           Flexdis86.OpTable
 import           Flexdis86.InstructionSet
 import           Flexdis86.Prefixes
+import           Flexdis86.Prefixes.REX ( REX(..), rexB, rexR, rexW )
 import           Flexdis86.Prefixes.Required ( Required, noRequired, requiredToByte )
+import qualified Flexdis86.VEX.Seen as VEX
 import           Flexdis86.Register
 import           Flexdis86.Segment
 import           Flexdis86.Sizes
@@ -96,7 +98,7 @@ findEncoding args def = do
   let oso = mkOSO def argTypes
   F.forM_ argTypes $ \at -> guard (matchOperandType oso at)
   let rex = mkREX argTypes
-  let vex = Nothing -- XXX: implement this
+  let vex = VEX.noVex -- XXX: implement this
   let notrack = False -- for now, not trying to use this feature
   return $ II { iiLockPrefix = NoLockPrefix
               -- ???: why is this always Size16? Can we do better
@@ -358,7 +360,7 @@ mkAssembledInstruction ::
   InstructionInstance ->
   m (AssembledInstruction B.Builder)
 mkAssembledInstruction ii = do
-  when (isJust (L.view prVEX pfxs)) $ do
+  when (VEX.hasVex (L.view prVEX pfxs)) $ do
     C.throwM VEXUnsupported
   mdisp <- encodeModRMDisp ii
   return $

--- a/src/Flexdis86/DefaultParser.hs
+++ b/src/Flexdis86/DefaultParser.hs
@@ -90,7 +90,7 @@ optableDefs = runGet getDefs (LBS.fromStrict optableBytes)
       if empty then return []
                else (:) <$> Bin.get <*> getDefs
 
-defaultX64Disassembler :: NextOpcodeTable
+defaultX64Disassembler :: Disassembler
 defaultX64Disassembler = p
   where p = case mkX64Disassembler optableDefs of
               Right v -> v

--- a/src/Flexdis86/Disassembler.hs
+++ b/src/Flexdis86/Disassembler.hs
@@ -24,6 +24,9 @@ This defines a disassembler based on optable definitions.
 {-# LANGUAGE TupleSections #-}
 module Flexdis86.Disassembler
   ( mkX64Disassembler
+  , Disassembler
+  , disLegacy
+  , disVex
   , NextOpcodeTable
   , nextOpcodeSize
   , disassembleInstruction
@@ -55,16 +58,19 @@ import           Lens.Micro.Extras (view)
 import           Prelude
 
 import           Flexdis86.ByteReader
-import qualified Flexdis86.Trie as Trie
 import           Flexdis86.InstructionSet
 import           Flexdis86.OpTable
 import           Flexdis86.Operand
 import           Flexdis86.Prefixes
+import           Flexdis86.Prefixes.REX (REX(..), rexW, unREX)
 import           Flexdis86.Prefixes.Required (noRequired, requiredToByte)
 import           Flexdis86.Prefixes.Seen (Seen, emptySeen, addPrefix, materializePrefixes, checkAllowed)
 import           Flexdis86.Register
 import           Flexdis86.Segment
 import           Flexdis86.Sizes
+import qualified Flexdis86.Trie as Trie
+import qualified Flexdis86.VEX.Allowed as VEXA
+import qualified Flexdis86.VEX.Seen as VEX
 
 {-
 Note [x86_64 disassembly]
@@ -143,8 +149,9 @@ assumption that the set of possible prefix bytes is disjoint from the set of
 bytes that appear as an instruction's first opcode byte, but this is not the
 case. Here are some examples of instructions that violate this assumption:
 
-* The lds and les instructions' opcodes begin with 0xc5 and 0xc4, respectively,
-  which clash with the two-byte and three-byte VEX prefixes, respectively.
+* The lds and les instructions' opcodes begin with 'VEX.vex2EscapeByte'
+  and 'VEX.vex3EscapeByte', respectively, which clash with the two-byte
+  and three-byte VEX prefixes, respectively.
 * The inc instruction can have opcodes beginning with 0x40 through 0x47, and
   the dec instruction can have opcodes beginning with 0x48 through 0x4f. All of
   these clash with possible REX prefixes.
@@ -182,28 +189,33 @@ are rather unique in that:
 * The VEX prefixes always appear at the very end of the prefix bytes, just
   before the instruction's opcode bytes.
 
-A useful consequence of these two properties is that VEX prefix bytes are a
-useful tool for disambiguating instructions with similar opcodes. And in fact,
-if you factor in VEX prefix bytes, then the vector instructions listed above
-aren't ambiguous at all, since the other instructions that share their opcodes
-do not accept VEX prefixes. As a result, we have decided to carve out a very
-special case in the lookup table and include VEX prefix bytes (but not any
-other forms of prefix bytes) in the paths. That is, we have:
+A useful consequence of these two properties is that "is a VEX prefix
+present?" is a clean binary disambiguator: the vector instructions listed
+above aren't ambiguous at all once you know VEX was or wasn't observed,
+since the other instructions that share their opcodes do not accept VEX
+prefixes.
 
-                                           Lookup table
-                                   --------------^---------------
-                                  /                              \
-                                 /                                \
-  ----------------------------------------------------------------------------------
-  | Prefix bytes (excluding VEX) | VEX prefix bytes | Opcode bytes | Operand bytes |
-  ----------------------------------------------------------------------------------
+We exploit this by splitting the lookup table into two disjoint tries: one
+for legacy-prefixed instructions, one for VEX-prefixed. See 'Disassembler'.
+During disassembly, the decoder reads bytes from the prefix stream; if it
+sees a 'VEX.vex3EscapeByte' or 'VEX.vex2EscapeByte' it reads the VEX payload
+bytes, packs them into a 'Flexdis86.VEX.Seen.VEX' value, and walks the
+VEX trie. Otherwise it walks the legacy trie. The two tries never
+interact, so there is no opcode-byte ambiguity between the two families
+at decode time.
 
-One downside to this special case is that we must increase the size of the
-lookup table slightly to accommodate VEX prefix bytes. Without VEX prefix
-bytes, the size of the table would be about 1,400 nodes, but with VEX prefix
-bytes, the size is about 13,000 nodes. That's still several orders of magnitude
-smaller than 5.8 million nodes, however, so we consider this an acceptable
-price to pay.
+The finer-grained VEX fields (m-mmmm, pp, L, W, vvvv) are validated at the
+leaf against the def's 'Flexdis86.VEX.Allowed.Allowed' mask via
+'Flexdis86.VEX.Allowed.vexContainedIn'. The def stores this mask as a
+packed 'Word32' (computed once at XML-parse time from the @/vex=@ spec);
+the leaf check is a handful of 'testBit's.
+
+With this structure the legacy trie holds ~1,341 def candidates at its
+leaves and the VEX trie holds 68 (see 'nextOpcodeSize'). An earlier
+version included the raw VEX prefix bytes in a single unified trie path,
+which worked but ballooned the combined count to ~13,000 - every @\/vex=@
+spec expanded into a cross product of ~R\/~X\/~B\/W\/vvvv\/L\/pp bytes
+along the trie path.
 
 The remaining challenges are the following instructions, which are all
 particular encodings of the nop instruction:
@@ -337,7 +349,7 @@ data RegTable a
 
 instance DS.NFData a => DS.NFData (RegTable a)
 
-type RMTable = RegTable [(Maybe VEX, Def)]
+type RMTable = RegTable [Def]
 
 data ModTable
      -- | @ModTable memTable regTable@
@@ -355,7 +367,7 @@ instance DS.NFData ModTable
 data OpcodeTableEntry
   = OpcodeTableEntry
       !(RegTable ModTable) -- Defs expecting a ModR/M byte
-      ![(Maybe VEX, Def)]  -- Defs not expecting a ModR/M byte
+      ![Def]        -- Defs not expecting a ModR/M byte
   deriving (Generic, Show)
 
 instance DS.NFData OpcodeTableEntry
@@ -369,7 +381,20 @@ newtype OpcodeTable = OpcodeTable (Trie.Trie8 OpcodeTableEntry)
 -- | A NextOpcodeTable describes a table of parsers to read based on the bytes.
 type NextOpcodeTable = Trie.Vec8 OpcodeTable
 
-type DefTableFn t = [(Maybe VEX, Def)] -> t
+-- | The pair of opcode tries used at runtime: one for legacy-prefixed
+-- instructions, one for VEX-prefixed. The decoder picks between them
+-- based on whether a 'VEX.vex3EscapeByte' or 'VEX.vex2EscapeByte' was observed
+-- in the prefix stream.
+data Disassembler = Disassembler
+  { disLegacy :: !NextOpcodeTable
+  , disVex    :: !NextOpcodeTable
+  }
+  deriving Show
+
+instance DS.NFData Disassembler where
+  rnf (Disassembler l v) = DS.rnf l `seq` DS.rnf v
+
+type DefTableFn t = [Def] -> t
 -- ^ Given a list of pairs of VEX prefixes and definitions, build a table of
 -- possible instructions.
 
@@ -490,40 +515,14 @@ nonVexPrefixBytes = HS.unions
       , notrackPrefixByte
       ]
 
--- | Given a 'Def', construct all possible combinations of bytes representing
--- valid VEX prefix and opcode bytes for that instruction. (See
--- @Note [x86_64 disassembly]@ for why we care about VEX prefix bytes in
--- particular.) Each element of the returned list consists of a pair where
--- the first part of the pair contains the raw bytes, and the second part of
--- the pair contains the corresponding 'VEX' (if one exists) and 'Def'.
-allVexPrefixesAndOpcodes :: Def -> [([Word8], (Maybe VEX, Def))]
-allVexPrefixesAndOpcodes def
-  | null (def ^. vexPrefixes)
-  = [ (def^.defOpcodes, (Nothing, def)) ]
-
-  | otherwise
-  = [ (vexBytes ++ def^.defOpcodes, (Just vex, def))
-    | (vexBytes, vex) <- mkVexPrefixes def ]
-  where
-    mkVexPrefixes :: Def -> [([Word8], VEX)]
-    mkVexPrefixes df = map cvt (df ^. vexPrefixes)
-      where
-      cvt pref =
-        case pref of
-          [ _, b ]      -> (pref, VEX2 b)
-          [ _, b1, b2 ] -> (pref, VEX3 b1 b2)
-          _             -> error "mkVexPrefixes: unexpected byte sequence"
-
--- | Given a list of instruction 'Def's, compute a lookup table for its VEX
--- prefix and opcode bytes. See @Note [x86_64 disassembly]@ for more details on
--- how this works.
+-- | Given a list of instruction 'Def's, compute a lookup table of opcode bytes.
 mkOpcodeTable :: [Def] -> OpcodeTable
 mkOpcodeTable defs =
-  OpcodeTable (Trie.mkTrie mkLeaf (concatMap allVexPrefixesAndOpcodes defs))
+  OpcodeTable (Trie.mkTrie mkLeaf [ (d ^. defOpcodes, d) | d <- defs ])
   where
-    mkLeaf :: [(Maybe VEX, Def)] -> OpcodeTableEntry
-    mkLeaf vexDefs =
-      let (defsWithModRM, defsWithoutModRM) = partition (expectsModRM . snd) vexDefs
+    mkLeaf :: [Def] -> OpcodeTableEntry
+    mkLeaf leafDefs =
+      let (defsWithModRM, defsWithoutModRM) = partition expectsModRM leafDefs
       in OpcodeTableEntry (checkRequiredReg defsWithModRM) defsWithoutModRM
 
 requireModCheck :: Def -> Bool
@@ -531,7 +530,7 @@ requireModCheck d = isJust (d^.requiredMod)
 
 mkModTable :: DefTableFn ModTable
 mkModTable defs
-  | any (requireModCheck . snd) defs =
+  | any requireModCheck defs =
     let memDef d =
           case d^.requiredMod of
             Just OnlyReg -> False
@@ -565,15 +564,15 @@ mkModTable defs
             RM_MMX  -> True
             RM_XMM {} -> True
             _       -> False
-        memTbl = checkRequiredRM (filter (memDef . snd) defs)
-        regTbl = checkRequiredRM (filter (regDef . snd) defs)
+        memTbl = checkRequiredRM (filter memDef defs)
+        regTbl = checkRequiredRM (filter regDef defs)
     in ModTable memTbl regTbl
   | otherwise = ModUnchecked (checkRequiredRM defs)
 
 checkRequiredReg :: DefTableFn (RegTable ModTable)
 checkRequiredReg defs
-  | any (\(_,d) -> d^.requiredReg /= NothingFin8) defs =
-    let p i (_,d) = i `matchesMaybeFin8` (d^.requiredReg)
+  | any (\d -> d^.requiredReg /= NothingFin8) defs =
+    let p i d = i `matchesMaybeFin8` (d^.requiredReg)
         eltFn i = mkModTable (filter (p i) defs)
     in RegTable (mkFin8Vector eltFn)
   | otherwise = RegUnchecked (mkModTable defs)
@@ -587,14 +586,14 @@ mkFin8Vector f = V.generate 8 g
             Nothing -> error $ "internal: Expected number between 0-7, received " ++ show i
 
 -- | Return true if the definition matches the Fin8 constraint
-matchRMConstraint :: Fin8 -> (Maybe VEX,Def) -> Bool
-matchRMConstraint i (_,d) = i `matchesMaybeFin8` (d^.requiredRM)
+matchRMConstraint :: Fin8 -> Def -> Bool
+matchRMConstraint i d = i `matchesMaybeFin8` (d^.requiredRM)
 
 -- | Check required RM if needed, then forward to final table.
 checkRequiredRM :: DefTableFn RMTable
 checkRequiredRM defs
     -- Split on the required RM value if any of the definitions depend on it
-  | any (\(_,d) -> d^.requiredRM /= NothingFin8) defs =
+  | any (\d -> d^.requiredRM /= NothingFin8) defs =
       RegTable (mkFin8Vector (\i -> filter (i `matchRMConstraint`) defs))
   | otherwise = RegUnchecked defs
 
@@ -619,11 +618,12 @@ read_disp8 = Disp8 <$> readSByte
 
 parseReadTable :: ByteReader m
                => Seen
+               -> VEX.VEX
                -> ModRM
-               -> [(Maybe VEX, Def)]
+               -> [Def]
                -> m InstructionInstance
-parseReadTable pc modRM dfs = do
-  (pfx, df) <- matchDefWithSeen pc dfs
+parseReadTable pc obsVex modRM dfs = do
+  (pfx, df) <- matchDefWithSeen pc obsVex dfs
   let osz = prefixOperandSizeConstraint pfx df
   let finish args =
         II
@@ -643,7 +643,7 @@ parseReadTable pc modRM dfs = do
 getReadTable ::
   ModRM ->
   RMTable ->
-  [(Maybe VEX, Def)]
+  [Def]
 getReadTable modRM (RegTable v) = v V.! fromIntegral (modRM_rm modRM)
 getReadTable _modRM (RegUnchecked m) = m
 
@@ -671,11 +671,13 @@ getRMTable modRM mtbl =
 -- with identical opcodes, and no more than that.
 validateSeen ::
   Seen ->
-  Maybe VEX ->
+  VEX.VEX ->
   Def ->
   Either String (Prefixes, Def)
-validateSeen pc mbVex def
-  | not (checkAllowed pc mbVex allowed reqPfx)
+validateSeen pc obsVex def
+  | not (VEXA.vexContainedIn obsVex (def ^. defAllowedVex))
+  = Left $ "Invalid VEX prefix for " ++ BSC.unpack (def ^. defMnemonic)
+  | not (checkAllowed pc obsVex allowed reqPfx)
   = Left $ "Invalid prefix bytes for " ++ BSC.unpack (def ^. defMnemonic)
   | validPrefix pfx def'
   = Right (pfx, def')
@@ -684,7 +686,7 @@ validateSeen pc mbVex def
   where
     allowed = def ^. defPrefix
     reqPfx = def ^. defRequiredPrefix
-    rawPfx = materializePrefixes pc mbVex allowed reqPfx
+    rawPfx = materializePrefixes pc obsVex allowed reqPfx
     (pfx, def') = applyNopFamilyFixups rawPfx def
 
 -- | Here is where we perform special cases of instructions that are similar
@@ -749,18 +751,19 @@ data DefSearchError
 -- encountered), return 'Left'.
 findDefWithSeen ::
   Seen ->
-  [(Maybe VEX, Def)] ->
+  VEX.VEX ->
+  [Def] ->
   Either DefSearchError (Prefixes, Def)
-findDefWithSeen pc defs =
+findDefWithSeen pc obsVex defs =
   case mapMaybe match defs of
     [pfxdef]    -> Right pfxdef
     []          -> Left NoDefFound
     res@(_:_:_) -> Left $ MultipleDefsFound
                         $ map (BSC.unpack . view defMnemonic . snd) res
   where
-    match :: (Maybe VEX, Def) -> Maybe (Prefixes, Def)
-    match (mbVex, def) =
-      case validateSeen pc mbVex def of
+    match :: Def -> Maybe (Prefixes, Def)
+    match def =
+      case validateSeen pc obsVex def of
         Left _err    -> Nothing
         Right pfxdef -> Just pfxdef
 
@@ -769,10 +772,11 @@ findDefWithSeen pc defs =
 matchDefWithSeen ::
   ByteReader m =>
   Seen ->
-  [(Maybe VEX, Def)] ->
+  VEX.VEX ->
+  [Def] ->
   m (Prefixes, Def)
-matchDefWithSeen pc defs =
-  case findDefWithSeen pc defs of
+matchDefWithSeen pc obsVex defs =
+  case findDefWithSeen pc obsVex defs of
     Right pfxdef -> pure pfxdef
     Left NoDefFound -> invalidInstruction
     Left (MultipleDefsFound defNms) -> error $ unlines $
@@ -781,32 +785,44 @@ matchDefWithSeen pc defs =
 -- | Parse instruction using byte reader.
 disassembleInstruction :: forall m
                         . ByteReader m
-                       => NextOpcodeTable
+                       => Disassembler
                        -> m InstructionInstance
-disassembleInstruction tr0 = loopPrefixBytes emptySeen
+disassembleInstruction dis = loopPrefixBytes emptySeen
   where
-    -- Parse as many bytes as possible that are known to be prefix bytes. Once
-    -- we encounter the first byte that isn't a prefix byte, move on to parsing
-    -- opcode bytes.
+    -- Parse as many bytes as possible that are known to be prefix bytes.
+    -- Once we encounter the first byte that isn't a prefix byte (or a VEX
+    -- escape), move on to parsing opcode bytes.
     loopPrefixBytes :: Seen -> m InstructionInstance
     loopPrefixBytes !acc = do
       b <- readByte
-      if |  HS.member b nonVexPrefixBytes
+      if |  b == VEX.vex2EscapeByte -> do
+             payload <- readByte
+             b0 <- readByte
+             loopOpcodes acc (VEX.fromVex2 payload) (disVex dis) b0
+
+         |  b == VEX.vex3EscapeByte -> do
+             b1 <- readByte
+             b2 <- readByte
+             b0 <- readByte
+             loopOpcodes acc (VEX.fromVex3 b1 b2) (disVex dis) b0
+
+         |  HS.member b nonVexPrefixBytes
          -> case addPrefix acc b of
               Just acc' -> loopPrefixBytes acc'
               Nothing   -> invalidInstruction
 
          |  otherwise
-         -> loopOpcodes acc tr0 b
+         -> loopOpcodes acc VEX.noVex (disLegacy dis) b
 
     -- Parse opcode byte and use them to navigate through the opcode table.
     -- Once we have parsed all of the opcode bytes in an instruction,
     -- disassemble the rest of the instruction.
     loopOpcodes :: Seen
+                -> VEX.VEX
                 -> NextOpcodeTable
                 -> Word8
                 -> m InstructionInstance
-    loopOpcodes !pc = go
+    loopOpcodes !pc !obsVex = go
       where
         go :: NextOpcodeTable -> Word8 -> m InstructionInstance
         go tr opcodeByte =
@@ -819,27 +835,27 @@ disassembleInstruction tr0 = loopPrefixBytes emptySeen
                  -- first. If one is found, there is an invariant that none
                  -- of the instruction candidates without a ModR/M byte
                  -- should validate with the set of parsed prefixes.
-                 Right (pfx, def) <- findDefWithSeen pc defsWithoutModRM
-              -> assert (all (\(mbVex, df) ->
-                               isLeft $ validateSeen pc mbVex df)
+                 Right (pfx, def) <- findDefWithSeen pc obsVex defsWithoutModRM
+              -> assert (all (\df -> isLeft $ validateSeen pc obsVex df)
                              (flattenRegTable defsWithModRM)) $
                  disassembleWithoutModRM def pfx
 
               |  otherwise
-              -> disassembleWithModRM pc defsWithModRM
+              -> disassembleWithModRM pc obsVex defsWithModRM
 
     -- Disassemble instruction candidates with a ModR/M byte.
     disassembleWithModRM :: Seen
+                         -> VEX.VEX
                          -> RegTable ModTable
                          -> m InstructionInstance
-    disassembleWithModRM pc tbl = do
+    disassembleWithModRM pc obsVex tbl = do
       modRM <- readModRM
       case tbl of
         RegTable v ->
           let mtbl = v V.! fromIntegral (modRM_reg modRM) in
-          parseReadTable pc modRM (getReadTable modRM (getRMTable modRM mtbl))
+          parseReadTable pc obsVex modRM (getReadTable modRM (getRMTable modRM mtbl))
         RegUnchecked mtbl ->
-          parseReadTable pc modRM (getReadTable modRM (getRMTable modRM mtbl))
+          parseReadTable pc obsVex modRM (getReadTable modRM (getRMTable modRM mtbl))
 
     -- Disassemble an instruction without a ModR/M byte.
     disassembleWithoutModRM :: Def
@@ -900,9 +916,10 @@ memSizeFn osz sz =
 
 
 getREX :: Prefixes -> REX
-getREX p = case p ^. prVEX of
-             Just vex -> vex ^. vexRex
-             _        -> p ^. prREX
+getREX p
+  | VEX.hasVex vex = VEX.vexRex vex
+  | otherwise  = p ^. prREX
+  where vex = p ^. prVEX
 
 readOffset :: ByteReader m => Segment -> Bool -> m AddrRef
 readOffset s aso
@@ -951,8 +968,9 @@ parseValue p osz mmrm tp = do
     OpType (Opcode_reg r) sz -> pure $ regSizeFn osz rex sz (rex_b rex .|. r)
     OpType (Reg_fixed r) sz  -> pure $ regSizeFn osz rex sz r
     OpType VVVV sz
-      | Just vx <- p ^. prVEX -> pure $ regSizeFn osz rex sz $ complement (vx ^. vexVVVV) .&. 0xF
+      | VEX.hasVex vx -> pure $ regSizeFn osz rex sz $ complement (VEX.vexVVVV vx) .&. 0xF
       | otherwise -> error "[VVVV_XMM] Missing VEX prefix "
+      where vx = p ^. prVEX
     OpType ImmediateSource BSize ->
       ByteImm <$> readByte
     OpType ImmediateSource WSize ->
@@ -1002,15 +1020,17 @@ parseValue p osz mmrm tp = do
       | Just sz <- mb     -> error ("[RM_XMM] Unexpected size: " ++ show sz)
 
       | Nothing <- mb
-      , Just vx <- p ^. prVEX
-      , vx ^. vex256      -> Mem256 <$> addr
+      , let vx = p ^. prVEX
+      , VEX.hasVex vx
+      , VEX.vex256 vx         -> Mem256 <$> addr
 
       | otherwise         -> Mem128 <$> addr
 
     VVVV_XMM mb
-      | Just vx <- p ^. prVEX ->
-          return $ largeReg p mb $ complement (vx ^. vexVVVV) .&. 0xF
+      | VEX.hasVex vx ->
+          return $ largeReg p mb $ complement (VEX.vexVVVV vx) .&. 0xF
       | otherwise -> error "[VVVV_XMM] Missing VEX prefix "
+      where vx = p ^. prVEX
 
     SEG s -> return $ SegmentValue s
     M_FP -> FarPointer <$> addr
@@ -1067,9 +1087,10 @@ largeReg :: Prefixes -> Maybe OperandSize -> Word8 -> Value
 largeReg p mb num =
   case mb of
 
-    Nothing | Just vx <- p ^. prVEX
-            , vx ^. vex256  -> useYMM
-            | otherwise     -> useXMM
+    Nothing | let vx = p ^. prVEX
+            , VEX.hasVex vx
+            , VEX.vex256 vx  -> useYMM
+            | otherwise  -> useXMM
 
     Just sz ->
       case sz of
@@ -1146,7 +1167,7 @@ data DisassembledAddr = DAddr { disOffset :: Int
                               deriving Show
 
 -- | Try disassemble returns the numbers of bytes read and an instruction instance.
-tryDisassemble :: NextOpcodeTable -> BS.ByteString -> (Int, Maybe InstructionInstance)
+tryDisassemble :: Disassembler -> BS.ByteString -> (Int, Maybe InstructionInstance)
 tryDisassemble p bs0 = decode bs0 $ runGetIncremental (disassembleInstruction p)
   where bytesRead bs = BS.length bs0 - BS.length bs
 
@@ -1163,7 +1184,7 @@ tryDisassemble p bs0 = decode bs0 $ runGetIncremental (disassembleInstruction p)
 -- | Parse the buffer as a list of instructions.
 --
 -- Returns a list containing offsets,
-disassembleBuffer :: NextOpcodeTable
+disassembleBuffer :: Disassembler
                   -> BS.ByteString
                      -- ^ Buffer to decompose
                   -> [DisassembledAddr]
@@ -1195,15 +1216,15 @@ disassembleBuffer p bs0 = group 0 (decode bs0 decoder)
 
 -- | Flatten all candidate defs stored in a 'RegTable' 'ModTable' into a
 -- list. Used by decoder assertions and for size accounting.
-flattenRegTable :: RegTable ModTable -> [(Maybe VEX, Def)]
+flattenRegTable :: RegTable ModTable -> [Def]
 flattenRegTable (RegUnchecked mt) = flattenModTable mt
 flattenRegTable (RegTable v) = concatMap flattenModTable (V.toList v)
 
-flattenModTable :: ModTable -> [(Maybe VEX, Def)]
+flattenModTable :: ModTable -> [Def]
 flattenModTable (ModUnchecked rm) = flattenRMTable rm
 flattenModTable (ModTable m r) = flattenRMTable m ++ flattenRMTable r
 
-flattenRMTable :: RMTable -> [(Maybe VEX, Def)]
+flattenRMTable :: RMTable -> [Def]
 flattenRMTable (RegUnchecked xs) = xs
 flattenRMTable (RegTable v) = concat (V.toList v)
 
@@ -1217,12 +1238,20 @@ nextOpcodeSize :: NextOpcodeTable -> Int
 nextOpcodeSize v = sum (opcodeTableSize <$> v)
 
 -- | Create an instruction parser from a list of pre-parsed 'Def's.
--- The caller is responsible for providing only supported defs (see
--- 'defSupported' in "Flexdis86.OpTable").
-mkX64Disassembler :: [Def] -> Either String NextOpcodeTable
-mkX64Disassembler defs =
-  case mOpTbl of
-    Trie.Branch v -> Right $! coerce v
-    Trie.Leaf{} -> Left "Unexpected OpcodeTableEntry as a top-level disassemble result"
+-- Defs are partitioned by whether they permit a VEX prefix; legacy
+-- and VEX defs end up in separate tries, dispatched between by the
+-- decoder based on the presence of a 'VEX.vex3EscapeByte' or
+-- 'VEX.vex2EscapeByte'.
+mkX64Disassembler :: [Def] -> Either String Disassembler
+mkX64Disassembler defs = do
+  legacy <- mkTop legacyDefs
+  vex    <- mkTop vexDefs
+  Right (Disassembler legacy vex)
   where
-    OpcodeTable mOpTbl = mkOpcodeTable defs
+    (vexDefs, legacyDefs) =
+      partition (VEXA.hasVexAllowed . view defAllowedVex) defs
+    mkTop ds = case mOpTbl of
+      Trie.Branch v -> Right $! coerce v
+      Trie.Leaf{} ->
+        Left "Unexpected OpcodeTableEntry as a top-level disassemble result"
+      where OpcodeTable mOpTbl = mkOpcodeTable ds

--- a/src/Flexdis86/OpTable.hs
+++ b/src/Flexdis86/OpTable.hs
@@ -34,7 +34,7 @@ module Flexdis86.OpTable
   , x87ModRM
   , defOperands
   , x64Compatible
-  , vexPrefixes
+  , defAllowedVex
   , supportedCPUReqs
     -- * Operand lookup
   , lookupOperandType
@@ -57,6 +57,7 @@ import           Flexdis86.Prefixes.Required
 import           Flexdis86.Register
 import           Flexdis86.Segment
 import           Flexdis86.Sizes
+import qualified Flexdis86.VEX.Allowed as VEX
 
 ------------------------------------------------------------------------
 -- Mode
@@ -175,8 +176,10 @@ data Def = Def  { _defMnemonic         :: !BS.ByteString
                 , _requiredReg :: {-# UNPACK #-} !MaybeFin8
                 , _requiredRM  :: {-# UNPACK #-} !MaybeFin8
                 , _x87ModRM    :: Maybe Fin64
-                , _vexPrefixes  :: ![ [Word8] ]
-                  -- ^ Allowed VEX prefixes for this instruction.
+                , _defAllowedVex :: !VEX.Allowed
+                  -- ^ Allowed VEX encodings for this instruction. An
+                  -- empty ('VEX.noVexAllowed') mask means no VEX
+                  -- prefix is permitted; anything else requires one.
                 , _defOperands  :: ![OperandType]
                 } deriving (Eq, Generic, Show)
 
@@ -253,8 +256,8 @@ requiredRM = lens _requiredRM (\s v -> s { _requiredRM = v })
 x87ModRM :: Lens' Def (Maybe Fin64)
 x87ModRM = lens _x87ModRM (\s v -> s { _x87ModRM = v })
 
-vexPrefixes :: Lens' Def [[Word8]]
-vexPrefixes = lens _vexPrefixes (\s v -> s { _vexPrefixes = v })
+defAllowedVex :: Lens' Def VEX.Allowed
+defAllowedVex = lens _defAllowedVex (\s v -> s { _defAllowedVex = v })
 
 -- | Operand descriptions.
 defOperands :: Lens' Def [OperandType]
@@ -273,7 +276,7 @@ supportedCPUReqs =
 x64Compatible :: Def -> Bool
 x64Compatible d =
   case d^.defOpcodes of
-    [b] | null (d^.vexPrefixes) && (b .&. 0xF0 == 0x40) -> False
+    [b] | not (VEX.hasVexAllowed (d^.defAllowedVex)) && (b .&. 0xF0 == 0x40) -> False
     _   -> valid64 (d^.modeLimit)
 
 -- | Return true if this definition is one supported by flexdis86.

--- a/src/Flexdis86/OpTable/Parse.hs
+++ b/src/Flexdis86/OpTable/Parse.hs
@@ -24,14 +24,13 @@ import           Control.Monad.State ( MonadState(..)
                                      , execStateT
                                      , gets
                                      )
-import           Data.Bits ((.|.), shiftL, shiftR)
+import           Data.Bits (shiftR)
 import qualified Data.Binary as Bin
 import           Data.Binary.Put (Put, runPut)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BSC
 import qualified Data.ByteString.Lazy as LBS
 import           Data.Char (isDigit, isSpace)
-import           Data.Containers.ListUtils (nubOrd)
 import qualified Data.List as List
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe)
@@ -54,6 +53,7 @@ import           Lens.Micro.Mtl ((%=), (.=), (?=), use)
 
 import           Flexdis86.OpTable
 import           Flexdis86.Prefixes.Allowed (allowedFromNames)
+import qualified Flexdis86.VEX.Allowed as VEX
 import           Flexdis86.Prefixes.Required (noRequired, orRequired, requiredFromByte)
 import           Flexdis86.Sizes ( SizeConstraint(..), ModConstraint(..)
                                  , asFin8, asFin64, maskFin8
@@ -254,131 +254,52 @@ parse_vendor v = do
       _       -> fail $ "Unknown vendor: " ++ show txt
 
 ------------------------------------------------------------------------
--- VEX prefix helpers (used only during parsing)
+-- VEX prefix spec parser
 
-data VexSpec = VexSpec
-  { vexUseVVVV    :: Maybe VexUseVVVV
-  , vexSize       :: VexSize
-  , vexImpSimd    :: Maybe VexImpSimd
-  , vexImpOpc     :: Maybe VexImpOpc
-  , vexW          :: Maybe VexW
-  , vexAllowShort :: Bool
-  } deriving (Eq, Show)
-
-data VexUseVVVV = VEX_NDS | VEX_NDD | VEX_DDS      deriving (Eq, Show)
-data VexSize    = Vex128 | Vex256                   deriving (Eq, Show)
-data VexImpSimd = Imp0x66 | Imp0xF3 | Imp0xF2       deriving (Eq, Show)
-data VexImpOpc  = Imp0x0F | Imp0x0F38 | Imp0x0F3A   deriving (Eq, Show)
-data VexW       = VexW0 | VexW1                     deriving (Eq, Show)
-
-parseVex :: String -> VexSpec
-parseVex inp =
-  VexSpec { vexUseVVVV    = vvvv
-          , vexSize       = size
-          , vexImpSimd    = impS
-          , vexImpOpc     = impO
-          , vexW          = w
-          , vexAllowShort = short
-          }
+-- | Parse a @\/vex=@ specification string (e.g. @\"NDS.128.66.0F.WIG\"@)
+-- directly into a packed 'VEX.Allowed' mask.
+parseVexAllowed :: String -> VEX.Allowed
+parseVexAllowed inp = case mmmm of
+  Nothing -> VEX.noVexAllowed
+  Just m  -> VEX.allowVex m pp l w vvvvFix15
   where
   ts0 = chunks inp
 
-  (vvvv, ts1) =
+  (vvvvFix15, ts1) =
     case ts0 of
-      f : fs | f == "NDS" -> (Just VEX_NDS, fs)
-             | f == "NDD" -> (Just VEX_NDD, fs)
-             | f == "DDS" -> (Just VEX_DDS, fs)
-      _                   -> (Nothing, ts0)
+      f : fs | f == "NDS" || f == "NDD" || f == "DDS" -> (False, fs)
+      _                                               -> (True,  ts0)
 
-  (size, ts2) =
+  (l, ts2) =
     case ts1 of
-      f : fs | f == "128" -> (Vex128, fs)
-             | f == "256" -> (Vex256, fs)
+      f : fs | f == "128" -> (VEX.L128, fs)
+             | f == "256" -> (VEX.L256, fs)
       _ -> error "VEX specification is missing its size field"
 
-  (impS, ts3) =
+  (pp, ts3) =
     case ts2 of
-      f : fs | f == "66" -> (Just Imp0x66, fs)
-             | f == "F2" -> (Just Imp0xF2, fs)
-             | f == "F3" -> (Just Imp0xF3, fs)
-      _                  -> (Nothing, ts2)
+      f : fs | f == "66" -> (VEX.Pp0x66, fs)
+             | f == "F2" -> (VEX.Pp0xF2, fs)
+             | f == "F3" -> (VEX.Pp0xF3, fs)
+      _                  -> (VEX.PpNone, ts2)
 
-  (impO, ts4) =
+  (mmmm, ts4) =
     case ts3 of
-      f : fs | f == "0F"   -> (Just Imp0x0F,   fs)
-             | f == "0F3A" -> (Just Imp0x0F3A, fs)
-             | f == "0F38" -> (Just Imp0x0F38, fs)
+      f : fs | f == "0F"   -> (Just VEX.M0x0F,   fs)
+             | f == "0F38" -> (Just VEX.M0x0F38, fs)
+             | f == "0F3A" -> (Just VEX.M0x0F3A, fs)
       _                    -> (Nothing, ts3)
 
-  (w, ts5) =
+  (w, _ts5) =
     case ts4 of
-      f : fs | f == "W0" -> (Just VexW0, fs)
-             | f == "W1" -> (Just VexW1, fs)
-      _                  -> (Nothing, ts4)
-
-  short =
-    case ts5 of
-      f : _ | f == "WIG" -> True
-      _                  -> False
+      f : fs | f == "W0" -> (VEX.W0,  fs)
+             | f == "W1" -> (VEX.W1,  fs)
+      _                  -> (VEX.WIG, ts4)
 
   chunks x = if null x then []
                        else case break (== '.') x of
                               (as, _:bs) -> as : chunks bs
                               _          -> [x]
-
-vexMayBeShort :: VexSpec -> Bool
-vexMayBeShort vp =
-  case vexImpOpc vp of
-    Just Imp0x0F38  -> False
-    Just Imp0x0F3A  -> False
-    _ -> case vexW vp of
-           Just VexW1 -> False
-           _          -> vexAllowShort vp
-
-vexToBytes :: VexSpec -> [[Word8]]
-vexToBytes vp = short ++ long
-  where
-  long  = [ [0xC4, b1, b2] | b1 <- longByte1, b2 <- longByte2 ]
-  short = if vexMayBeShort vp then [ [0xC5, b] | b <- shortByte ] else []
-
-  shortByte = nubOrd
-              [ field 7 r .|. field 3 vvvv .|. field 2 l .|. pp
-              | r <- [0, 1], vvvv <- vvvvVals, l <- lVals, pp <- ppVals ]
-  longByte1 = nubOrd
-              [ field 5 rxb .|. m
-              | rxb <- [0 .. 7], m <- mmmmVals ]
-  longByte2 = nubOrd
-              [ field 7 ww .|. field 3 vvvv .|. field 2 l .|. pp
-              | ww <- wVals, vvvv <- vvvvVals, l <- lVals, pp <- ppVals ]
-
-  field amt x = shiftL x amt
-
-  vvvvVals = case vexUseVVVV vp of
-               Nothing -> [15]
-               Just _  -> [0 .. 15]
-
-  wVals    = case vexW vp of
-               Nothing    -> [0, 1]
-               Just VexW0 -> [0]
-               Just VexW1 -> [1]
-
-  lVals    = case vexSize vp of
-               Vex128 -> [0]
-               Vex256 -> [1]
-
-  ppVals   = case vexImpSimd vp of
-               Nothing      -> [0]
-               Just Imp0x66 -> [1]
-               Just Imp0xF3 -> [2]
-               Just Imp0xF2 -> [3]
-
-  mmmmVals = case vexImpOpc vp of
-               Nothing  -> []
-               Just imp ->
-                 case imp of
-                   Imp0x0F   -> [1]
-                   Imp0x0F38 -> [2]
-                   Imp0x0F3A -> [3]
 
 ------------------------------------------------------------------------
 -- Opcode / mnemonic parsers
@@ -462,7 +383,7 @@ parse_opcode nm = do
       -> setRequiredPrefix b
     _ | Just r <- List.stripPrefix "/vex=" nm
       -> do setDefCPUReq AVX
-            vexPrefixes .= vexToBytes (parseVex r)
+            defAllowedVex .= parseVexAllowed r
     _ -> fail $ "Unexpected opcode: " ++ show nm
 
 isMnemonic :: String -> Bool
@@ -531,7 +452,7 @@ parse_def nm syns creq v = do
                  , _requiredReg        = NothingFin8
                  , _requiredRM         = NothingFin8
                  , _x87ModRM           = Nothing
-                 , _vexPrefixes        = []
+                 , _defAllowedVex      = VEX.noVexAllowed
                  , _defOperands        = oprnds
                  }
     d <- seq d0 $ flip execStateT d0 $ mapM_ parse_opcode (words opc_text)

--- a/src/Flexdis86/Prefixes.hs
+++ b/src/Flexdis86/Prefixes.hs
@@ -12,11 +12,6 @@ Defines prefix operations.
 
 module Flexdis86.Prefixes
   ( Prefixes(..)
-  , REX(..)
-  , rexW
-  , rexR
-  , rexB
-  , rexX
   , SegmentPrefix(..)
   , prLockPrefix
   , prSP
@@ -43,10 +38,6 @@ module Flexdis86.Prefixes
   , setDefault
   , LockPrefix(..)
   , ppLockPrefix
-  , VEX(..)
-  , vexRex
-  , vexVVVV
-  , vex256
   ) where
 
 import qualified Control.DeepSeq as DS
@@ -56,8 +47,9 @@ import           GHC.Generics
 import           Lens.Micro (Lens', lens, (^.))
 import           Numeric ( showHex )
 import qualified Prettyprinter as PP
-import           Text.Printf
 
+import           Flexdis86.Prefixes.REX (REX)
+import qualified Flexdis86.VEX.Seen as VEX
 import           Flexdis86.Segment
 import           Flexdis86.Sizes
 
@@ -151,46 +143,6 @@ ppLockPrefix RepNZPrefix = "repnz"
 -----------------------------------------------------------------------
 -- REX
 
--- | REX value for 64-bit mode.
-newtype REX = REX { unREX :: Word8 }
-  deriving (Eq, Generic)
-
-instance DS.NFData REX
-
-setBitTo :: (B.Bits b) => b -> Int -> Bool -> b
-setBitTo bits bitNo val
-  | val = B.setBit bits bitNo
-  | otherwise = B.clearBit bits bitNo
-
--- | Indicates if 64-bit operand size should be used.
-rexW :: Lens' REX Bool
-rexW = lens ((`B.testBit` 3) . unREX) (\(REX r) v -> REX (setBitTo r 3 v))
-
--- | Extension of ModR/M reg field.
-rexR :: Lens' REX Bool
-rexR = lens ((`B.testBit` 2) . unREX) (\(REX r) v -> REX (setBitTo r 2 v))
-
--- | Extension of SIB index field.
-rexX :: Lens' REX Bool
-rexX = lens ((`B.testBit` 1) . unREX) (\(REX r) v -> REX (setBitTo r 1 v))
-
--- | Extension of ModR/M r/m field, SIB base field, or Opcode reg field.
-rexB :: Lens' REX Bool
-rexB = lens ((`B.testBit` 0) . unREX) (\(REX r) v -> REX (setBitTo r 0 v))
-
-instance Show REX where
-  show (REX rex) = printf "0b%08b" rex
-
-
------------------------------------------------------------------------
--- VEX
-
-data VEX = VEX2 Word8{-1-}              -- ^ Byte of a 2-byte VEX prefix
-         | VEX3 Word8{-1-} Word8{-2-}   -- ^ Byte 1 and 2 of 3-byte VEX prefix
-           deriving (Eq, Generic, Show)
-
-instance DS.NFData VEX
-
 -----------------------------------------------------------------------
 -- Prefixes
 
@@ -198,7 +150,7 @@ instance DS.NFData VEX
 data Prefixes = Prefixes { _prLockPrefix :: !LockPrefix
                          , _prSP  :: !SegmentPrefix
                          , _prREX :: !REX
-                         , _prVEX :: !(Maybe VEX)
+                         , _prVEX :: !VEX.VEX
                          , _prASO :: !Bool
                          , _prOSO :: !Bool
                          , _prNoTrack :: !Bool
@@ -206,51 +158,6 @@ data Prefixes = Prefixes { _prLockPrefix :: !LockPrefix
                 deriving (Eq, Generic, Show)
 
 instance DS.NFData Prefixes
-
-vexLens :: (Word8 -> a) ->
-           (Word8 -> Word8 -> a) ->
-           (Word8 -> a -> Word8) ->
-           (Word8 -> Word8 -> a -> (Word8,Word8)) ->
-           Lens' VEX a
-vexLens get1 get2 upd1 upd2 = lens getter updater
-  where getter vex = case vex of
-                       VEX2 b     -> get1 b
-                       VEX3 b1 b2 -> get2 b1 b2
-        updater old a = case old of
-                          VEX2 b     -> VEX2 (upd1 b a)
-                          VEX3 b1 b2 -> let (b1',b2') = upd2 b1 b2 a
-                                        in VEX3 b1' b2'
-
--- | Are we using 256-bit vectors
-vex256 :: Lens' VEX Bool
-vex256 = vexLens gt (\_ b2 -> gt b2)
-                 st (\b1 b2 a -> (b1, st b2 a))
-  where
-  gt b   = B.testBit b 2
-  st b v = if v then B.setBit b 2 else B.clearBit b 2
-
-
--- | REX info from VEX prefix
-vexRex :: Lens' VEX REX
-vexRex = vexLens gt1 gt2 st1 st2
-  where
-  gt1 b      = REX (0x40 B..|. B.shiftR (B.complement b B..&. 0x80) 5)
-  gt2 b1 b2  = REX (0x40 B..|. B.shiftR (B.complement b2 B..&. 0x80) 4
-                         B..|. B.shiftR (B.complement b1 B..&. 0xE0) 5)
-
-  st1 b v     = if v ^. rexR then B.clearBit b 7 else B.setBit b 7
-  st2 b1 b2 v = ( (b1 B..&. 0x1F) B..|. (B.complement (unREX v) `B.shiftL` 5)
-                , if v ^. rexW then B.clearBit b2 7 else B.setBit b2 7
-                )
-
--- | The VVVV field.  We return it as is.  Note that when used to encode
--- registers, the byte needs to be complemented.
-vexVVVV :: Lens' VEX Word8
-vexVVVV = vexLens gt (\_ b2 -> gt b2)
-                  st (\b1 b2 v -> (b1, st b2 v))
-  where
-  gt b   = B.shiftR b 3 B..&. 0xF
-  st b v = (b B..&. 0x87) B..|. B.shiftL (v B..&. 0xF) 3
 
 prLockPrefix :: Lens' Prefixes LockPrefix
 prLockPrefix = lens _prLockPrefix (\s v -> s { _prLockPrefix = v })
@@ -261,7 +168,7 @@ prSP = lens _prSP (\s v -> s { _prSP = v})
 prREX :: Lens' Prefixes REX
 prREX = lens _prREX (\s v -> s { _prREX = v })
 
-prVEX :: Lens' Prefixes (Maybe VEX)
+prVEX :: Lens' Prefixes VEX.VEX
 prVEX = lens _prVEX (\s v -> s { _prVEX = v })
 
 prASO :: Lens' Prefixes Bool

--- a/src/Flexdis86/Prefixes/REX.hs
+++ b/src/Flexdis86/Prefixes/REX.hs
@@ -1,0 +1,53 @@
+{- |
+Module      : Flexdis86.Prefixes.REX
+Copyright   : (c) Galois, Inc, 2026
+
+The @REX@ prefix byte and its bit lenses.
+-}
+
+{-# LANGUAGE DeriveGeneric #-}
+
+module Flexdis86.Prefixes.REX
+  ( REX(..)
+  , rexW
+  , rexR
+  , rexX
+  , rexB
+  ) where
+
+import qualified Control.DeepSeq as DS
+import qualified Data.Bits as B
+import           Data.Word (Word8)
+import           GHC.Generics
+import           Lens.Micro (Lens', lens)
+import           Text.Printf
+
+-- | REX value for 64-bit mode.
+newtype REX = REX { unREX :: Word8 }
+  deriving (Eq, Generic)
+
+instance DS.NFData REX
+
+setBitTo :: (B.Bits b) => b -> Int -> Bool -> b
+setBitTo bits bitNo val
+  | val = B.setBit bits bitNo
+  | otherwise = B.clearBit bits bitNo
+
+-- | Indicates if 64-bit operand size should be used.
+rexW :: Lens' REX Bool
+rexW = lens ((`B.testBit` 3) . unREX) (\(REX r) v -> REX (setBitTo r 3 v))
+
+-- | Extension of ModR/M reg field.
+rexR :: Lens' REX Bool
+rexR = lens ((`B.testBit` 2) . unREX) (\(REX r) v -> REX (setBitTo r 2 v))
+
+-- | Extension of SIB index field.
+rexX :: Lens' REX Bool
+rexX = lens ((`B.testBit` 1) . unREX) (\(REX r) v -> REX (setBitTo r 1 v))
+
+-- | Extension of ModR/M r/m field, SIB base field, or Opcode reg field.
+rexB :: Lens' REX Bool
+rexB = lens ((`B.testBit` 0) . unREX) (\(REX r) v -> REX (setBitTo r 0 v))
+
+instance Show REX where
+  show (REX rex) = printf "0b%08b" rex

--- a/src/Flexdis86/Prefixes/Seen.hs
+++ b/src/Flexdis86/Prefixes/Seen.hs
@@ -28,7 +28,9 @@ import           Data.Word (Word8, Word16, Word64)
 import           Flexdis86.Prefixes
 import           Flexdis86.Prefixes.Allowed
 import           Flexdis86.Prefixes.Code
+import           Flexdis86.Prefixes.REX (REX(..))
 import           Flexdis86.Prefixes.Required
+import qualified Flexdis86.VEX.Seen as VEX
 
 -- | What prefix bytes have been observed in the byte stream. Wraps a
 -- 'PrefixCode'; see "Flexdis86.Prefixes.Code" for the bit layout. The
@@ -140,8 +142,8 @@ lookupSegByte pc@(PrefixCode w_) =
 -- 'Flexdis86.OpTable.defPrefix', which already has the required-prefix
 -- bit OR'd in at parse time), so 'containedIn' can be a single bitwise
 -- test.
-checkAllowed :: Seen -> Maybe VEX -> Allowed -> Required -> Bool
-checkAllowed (Seen seen) mbVex allowed req =
+checkAllowed :: Seen -> VEX.VEX -> Allowed -> Required -> Bool
+checkAllowed (Seen seen) vex allowed req =
   seen `containedIn` allowedCode allowed && requiredSeen && rexVexDisjoint
   where
     -- A def with a required prefix only validates when that bit was
@@ -151,9 +153,7 @@ checkAllowed (Seen seen) mbVex allowed req =
       in rc == zeroBits || seen .&. rc /= zeroBits
 
     -- Having both REX and VEX prefixes is #UD.
-    rexVexDisjoint = seen .&. rexSeenBit == zeroBits || case mbVex of
-      Nothing -> True
-      Just _  -> False
+    rexVexDisjoint = seen .&. rexSeenBit == zeroBits || not (VEX.hasVex vex)
 {-# INLINE checkAllowed #-}
 
 -- | Reconstruct a 'Prefixes' value from the observed prefixes, the VEX
@@ -172,12 +172,12 @@ checkAllowed (Seen seen) mbVex allowed req =
 --  * Segment/notrack (0x3E): materializes as a notrack flag if the def's
 --    allowed set has @notrack@ semantics ('notrackSemanticBit') without
 --    allowing any segment override; otherwise it is a DS segment override.
-materializePrefixes :: Seen -> Maybe VEX -> Allowed -> Required -> Prefixes
-materializePrefixes (Seen seen) mbVex allowed req = Prefixes
+materializePrefixes :: Seen -> VEX.VEX -> Allowed -> Required -> Prefixes
+materializePrefixes (Seen seen) vex allowed req = Prefixes
   { _prLockPrefix = lockPrefix
   , _prSP = SegmentPrefix segByte
   , _prREX = REX rexByte
-  , _prVEX = mbVex
+  , _prVEX = vex
   , _prASO = legacy .&. asoBit /= zeroBits
   , _prOSO = legacy .&. osoBit /= zeroBits
   , _prNoTrack = asNotrack

--- a/src/Flexdis86/VEX/Allowed.hs
+++ b/src/Flexdis86/VEX/Allowed.hs
@@ -1,0 +1,171 @@
+{- |
+Module      : Flexdis86.VEX.Allowed
+Copyright   : (c) Galois, Inc, 2026
+
+The set of VEX encodings a 'Flexdis86.OpTable.Def' permits, packed as
+a @(mask, expected)@ pair that is matched directly against the raw
+VEX 'Word16' bytes from 'Flexdis86.VEX.Seen.VEX'. Every VEX field in
+the optable is either \"fixed to one value\" or \"don't care\", so
+the check collapses to
+
+@
+  v .&. mask == expected
+@
+
+Layout (mirrors the raw VEX 'Word16' in 'Flexdis86.VEX.Seen.VEX'):
+
+@
+  byte 0 - VEX3 byte 1
+    [7]     ~R           never fixed
+    [6]     ~X           never fixed
+    [5]     ~B           never fixed
+    [4:0]   m-mmmm       always fixed (mask=0x1F)
+
+  byte 1 - VEX3 byte 2
+    [7]     W            fixed for W0\/W1, wildcard for WIG
+    [6:3]   ~vvvv        fixed to 0 when vvvv=15, wildcard otherwise
+    [2]     L            always fixed
+    [1:0]   pp           always fixed
+@
+
+The 'noVexAllowed' sentinel is @'Allowed' 0 0@: since any real VEX
+observation has @m-mmmm /= 0@, @v .&. 0 == 0@ only holds when @v@ is
+the 'noVex' sentinel, so non-VEX defs validate against \"no VEX seen\"
+and reject any real VEX bytes.
+-}
+
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE BinaryLiterals #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Flexdis86.VEX.Allowed
+  ( Allowed
+  , noVexAllowed
+  , hasVexAllowed
+  , vexContainedIn
+    -- * Construction
+  , allowVex
+  , VexMmmm(..)
+  , VexPp(..)
+  , VexL(..)
+  , VexW(..)
+  ) where
+
+import           Control.DeepSeq (NFData(rnf))
+import           Data.Binary (Binary(get, put))
+import           Data.Bits ( (.&.), (.|.), shiftL )
+import           Data.Word (Word8, Word16)
+
+import qualified Flexdis86.VEX.Seen as VEX
+
+-- | Packed VEX-encoding constraint for a 'Def'. See the module
+-- haddock for the layout.
+data Allowed = Allowed {-# UNPACK #-} !Word16 {-# UNPACK #-} !Word16
+  deriving (Eq, Ord, Show)
+
+-- | Strict in both fields - the constructor already is, so 'rnf' is a
+-- no-op.
+instance NFData Allowed where
+  rnf !_ = ()
+
+-- | Big-endian pair of 'Word16's - matches the 'Data.Binary' default
+-- for 'Word16'.
+instance Binary Allowed where
+  put (Allowed m e) = put m *> put e
+  get = Allowed <$> get <*> get
+
+-- | \"No VEX prefix is permitted for this Def.\" With mask=0 and
+-- expected=0, @v .&. 0 == 0@ is 'True' only for @v = 'VEX.noVex'@,
+-- so this matches a missing VEX observation and rejects any real one.
+noVexAllowed :: Allowed
+noVexAllowed = Allowed 0 0
+{-# INLINE noVexAllowed #-}
+
+-- | Does this 'Allowed' permit any VEX encoding at all? True iff the
+-- mask pins any bits (non-VEX defs use mask=0).
+hasVexAllowed :: Allowed -> Bool
+hasVexAllowed (Allowed m _) = m /= 0
+{-# INLINE hasVexAllowed #-}
+
+-- | Does the observed VEX validate against an 'Allowed' mask? Two
+-- arithmetic ops: @v .&. mask == expected@. The caller is responsible
+-- for only invoking this with a real VEX when the def requires one
+-- (the split-trie decoder does so structurally - see
+-- @Note [x86_64 disassembly]@).
+vexContainedIn :: VEX.VEX -> Allowed -> Bool
+vexContainedIn seen (Allowed mask expected) =
+  VEX.vexWord seen .&. mask == expected
+{-# INLINE vexContainedIn #-}
+
+------------------------------------------------------------------------
+-- Construction
+
+-- | VEX @m-mmmm@ field: which opcode-escape prefix the instruction
+-- implies.
+data VexMmmm = M0x0F | M0x0F38 | M0x0F3A
+  deriving (Eq, Show)
+
+-- | VEX @pp@ field: the implied legacy SIMD prefix.
+data VexPp = PpNone | Pp0x66 | Pp0xF3 | Pp0xF2
+  deriving (Eq, Show)
+
+-- | VEX @L@ field: vector length.
+data VexL = L128 | L256
+  deriving (Eq, Show)
+
+-- | VEX @W@ field: 'WIG' means the def accepts both @W=0@ and @W=1@.
+data VexW = W0 | W1 | WIG
+  deriving (Eq, Show)
+
+mmmmBits :: VexMmmm -> Word8
+mmmmBits = \case
+  M0x0F   -> 1
+  M0x0F38 -> 2
+  M0x0F3A -> 3
+
+ppBits :: VexPp -> Word8
+ppBits = \case
+  PpNone -> 0
+  Pp0x66 -> 1
+  Pp0xF3 -> 2
+  Pp0xF2 -> 3
+
+lBits :: VexL -> Word8
+lBits = \case
+  L128 -> 0
+  L256 -> 1
+
+-- | Build the 'Allowed' mask for a single VEX-permitting 'Def'.
+allowVex
+  :: VexMmmm
+  -> VexPp
+  -> VexL
+  -> VexW
+  -> Bool
+     -- ^ @'True'@ iff @vvvv@ is fixed at 15 (i.e.\ @~vvvv = 0@);
+     --   @'False'@ iff any @vvvv@ in @0..15@ is permitted
+  -> Allowed
+allowVex m p l w vvvvFix15 = Allowed mask expected
+  where
+    -- byte 0: m-mmmm in [4:0]; ~R ~X ~B in [7:5] are never fixed.
+    mask0, exp0 :: Word8
+    mask0 = 0b00011111
+    exp0  = mmmmBits m
+
+    -- byte 1: pp in [1:0], L in [2], ~vvvv in [6:3], W in [7].
+    mask1, exp1 :: Word8
+    mask1 = 0b00000111                              -- pp + L always fixed
+        .|. (if vvvvFix15 then 0b01111000 else 0)   -- ~vvvv = 0
+        .|. (case w of WIG -> 0; _ -> 0b10000000)   -- W
+    exp1  = ppBits p
+        .|. (lBits l `shiftL` 2)
+        .|. (case w of W0 -> 0; W1 -> 1 `shiftL` 7; WIG -> 0)
+
+    mask     = pack mask0 mask1
+    expected = pack exp0  exp1
+
+pack :: Word8 -> Word8 -> Word16
+pack lo hi = fromIntegral @Word8 @Word16 lo
+         .|. (fromIntegral @Word8 @Word16 hi `shiftL` 8)
+{-# INLINE pack #-}

--- a/src/Flexdis86/VEX/Seen.hs
+++ b/src/Flexdis86/VEX/Seen.hs
@@ -1,0 +1,170 @@
+{- |
+Module      : Flexdis86.VEX.Seen
+Copyright   : (c) Galois, Inc, 2026
+
+The observed @VEX@ prefix, packed as two raw bytes inside a single
+'Word16'. Every constructed 'VEX' is in canonical VEX3 form: VEX2
+observations (via 'fromVex2') are normalized on entry by filling in
+the implicit @~X=1@, @~B=1@, @W=0@, @m-mmmm=00001@ fields.
+Validation against a def's permitted set
+('Flexdis86.VEX.Allowed.vexContainedIn') reads 'vexWord' directly -
+no per-field extraction.
+
+The sentinel 'noVex' ('VEX' @0@) means \"no VEX prefix observed.\" No
+valid VEX encoding can alias this: a real VEX3 byte 1 has
+@m-mmmm \\in \\{1, 2, 3\\}@, so its low five bits are always nonzero.
+
+Bit layout (little-endian into the 'Word16'):
+
+@
+  byte 0 (low) - VEX3 byte 1
+    [7]     ~R
+    [6]     ~X
+    [5]     ~B
+    [4:0]   m-mmmm    (1=0x0F, 2=0x0F 38, 3=0x0F 3A)
+
+  byte 1 (high) - VEX3 byte 2
+    [7]     W
+    [6:3]   ~vvvv
+    [2]     L         (0 = 128-bit, 1 = 256-bit)
+    [1:0]   pp        (implied SIMD prefix)
+@
+-}
+
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Flexdis86.VEX.Seen
+  ( VEX(..)
+  , noVex
+  , hasVex
+  , fromVex2
+  , fromVex3
+    -- * Escape bytes
+  , vex2EscapeByte
+  , vex3EscapeByte
+    -- * Accessors
+  , vexRex
+  , vexVVVV
+  , vex256
+  , vexByte1
+  , vexByte2
+    -- * Raw access
+  , vexWord
+  ) where
+
+import           Control.Exception (assert)
+import qualified Control.DeepSeq as DS
+import           Data.Binary (Binary)
+import           Data.Bits ( (.&.), (.|.), complement, shiftL, shiftR
+                           , testBit
+                           )
+import           Data.Word (Word8, Word16)
+
+import           Flexdis86.Prefixes.REX (REX(..))
+
+-- | Packed VEX prefix. @'VEX' 0@ is the distinguished \"no VEX\"
+-- value; any other 'Word16' encodes a VEX3-normalized pair of raw VEX
+-- bytes. See the module haddock for the exact layout.
+newtype VEX = VEX Word16
+  deriving (Binary, DS.NFData, Eq, Ord, Show)
+
+-- | The \"no VEX prefix observed\" sentinel. Equal to @'VEX' 0@;
+-- compare with @== 'noVex'@ or @/= 'noVex'@ to branch on presence.
+noVex :: VEX
+noVex = VEX 0
+{-# INLINE noVex #-}
+
+-- | Is a VEX prefix present?
+hasVex :: VEX -> Bool
+hasVex v = v /= noVex
+{-# INLINE hasVex #-}
+
+-- | Escape byte introducing a two-byte VEX prefix (one payload byte
+-- follows).
+vex2EscapeByte :: Word8
+vex2EscapeByte = 0xC5
+
+-- | Escape byte introducing a three-byte VEX prefix (two payload bytes
+-- follow).
+vex3EscapeByte :: Word8
+vex3EscapeByte = 0xC4
+
+-- | Build a 'VEX' from a VEX2 payload byte (the byte following a
+-- 'vex2EscapeByte'). Normalized to VEX3 form in-place: byte 1 is @~R@
+-- from the payload's high bit with @~X=1@, @~B=1@, @m-mmmm=00001@; byte
+-- 2 is the payload with @W=0@ (VEX2 implies @W=0@).
+fromVex2 :: Word8 -> VEX
+fromVex2 payload =
+  packBytes ((payload .&. 0x80) .|. 0x61) (payload .&. 0x7F)
+{-# INLINE fromVex2 #-}
+
+-- | Build a 'VEX' from the two VEX3 payload bytes (the bytes following
+-- a 'vex3EscapeByte').
+fromVex3 :: Word8 -> Word8 -> VEX
+fromVex3 = packBytes
+{-# INLINE fromVex3 #-}
+
+packBytes :: Word8 -> Word8 -> VEX
+packBytes b1 b2 =
+  VEX (fromIntegral @Word8 @Word16 b1 .|. (fromIntegral @Word8 @Word16 b2 `shiftL` 8))
+{-# INLINE packBytes #-}
+
+-- | Raw VEX3 byte 1. Zero when 'hasVex' is 'False'.
+vexByte1 :: VEX -> Word8
+vexByte1 (VEX w) = fromIntegral @Word16 @Word8 w
+{-# INLINE vexByte1 #-}
+
+-- | Raw VEX3 byte 2. Zero when 'hasVex' is 'False'.
+vexByte2 :: VEX -> Word8
+vexByte2 (VEX w) = fromIntegral @Word16 @Word8 (w `shiftR` 8)
+{-# INLINE vexByte2 #-}
+
+------------------------------------------------------------------------
+-- Accessors
+--
+-- For a canonical VEX3 encoding (which is what we always store), the
+-- REX, vvvv, L, and pp fields are pure bit extractions. No case on
+-- VEX2 vs VEX3 is needed because 'mkVEX2' fills in VEX3's implicit
+-- fields.
+
+-- | The implied REX byte. Combines @~R@\/@~X@\/@~B@ from byte 1 and
+-- @W@ from byte 2, inverting and shifting into the REX byte's
+-- @0b0100WRXB@ layout.
+--
+-- Precondition: 'hasVex'. Asserted, but not checked in production.
+vexRex :: VEX -> REX
+vexRex v@(VEX w) =
+  assert (hasVex v) $
+  let b1 = fromIntegral @Word16 @Word8 w
+      b2 = fromIntegral @Word16 @Word8 (w `shiftR` 8)
+  in REX ( 0x40
+      .|. (complement b2 .&. 0x80) `shiftR` 4         -- W from byte 2 bit 7 -> REX bit 3
+      .|. (complement b1 .&. 0xE0) `shiftR` 5         -- ~R ~X ~B -> REX bits 2..0
+         )
+{-# INLINE vexRex #-}
+
+-- | The 4-bit @vvvv@ source register (de-inverted). Callers that
+-- interpret it as a register index typically complement and mask.
+--
+-- Precondition: 'hasVex'. Asserted, but not checked in production.
+vexVVVV :: VEX -> Word8
+vexVVVV v = assert (hasVex v) $ (vexByte2 v `shiftR` 3) .&. 0xF
+{-# INLINE vexVVVV #-}
+
+-- | Is this a 256-bit vector operation (L bit of byte 2)?
+--
+-- Precondition: 'hasVex'. Asserted, but not checked in production.
+vex256 :: VEX -> Bool
+vex256 v = assert (hasVex v) $ testBit (vexByte2 v) 2
+{-# INLINE vex256 #-}
+
+------------------------------------------------------------------------
+-- Raw access
+
+-- | The raw packed VEX3-normalized bytes as a single 'Word16'. Used by
+-- 'Flexdis86.VEX.Allowed.vexContainedIn' for direct bitmask validation.
+vexWord :: VEX -> Word16
+vexWord (VEX w) = w
+{-# INLINE vexWord #-}


### PR DESCRIPTION
Shrink the trie for cache-friendliness. Replace data-dependent loads with a bit of bit arithmetic. VEX opcodes have a separate trie with no prefix bytes. This is ideal because VEX is rare in practice, and we want the hot-path trie to fit in as small a cache as possible.